### PR TITLE
Use translations for login feedback and placeholders

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -7,6 +7,7 @@
     "noUsersFound": "(No users yet)",
     "feedbackNameEmpty": "Please enter a name!",
     "feedbackWelcome": "Welcome, {userName}!",
+    "feedbackError": "An error occurred: {error}",
     "title_found_users": "Found Users",
     "button_confirm": "Confirm",
 

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -7,6 +7,7 @@
   "noUsersFound": "(Aún no hay usuarios)",
   "feedbackNameEmpty": "¡Por favor, ingresa un nombre!",
   "feedbackWelcome": "¡Bienvenido, {userName}!",
+  "feedbackError": "Ocurrió un error: {error}",
   "title_found_users": "Usuarios encontrados",
   "button_confirm": "Confirmar",
 

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -7,6 +7,7 @@
     "noUsersFound": "(Aucun utilisateur pour le moment)",
     "feedbackNameEmpty": "Veuillez entrer un nom !",
     "feedbackWelcome": "Bienvenue, {userName} !",
+    "feedbackError": "Une erreur s'est produite : {error}",
     "title_found_users": "Utilisateurs trouvés",
     "button_confirm": "Confirmer",
   

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -7,6 +7,7 @@
     "noUsersFound": "（ユーザーがまだいません）",
     "feedbackNameEmpty": "名前を入力してください！",
     "feedbackWelcome": "ようこそ、{userName}さん！",
+    "feedbackError": "エラーが発生しました: {error}",
     "title_found_users": "見つかったユーザー",
     "button_confirm": "確認",
   

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -7,6 +7,7 @@
   "noUsersFound": "(Nenhum usuário ainda)",
   "feedbackNameEmpty": "Por favor, insira um nome!",
   "feedbackWelcome": "Bem-vindo, {userName}!",
+  "feedbackError": "Ocorreu um erro: {error}",
   "title_found_users": "Usuários encontrados",
   "button_confirm": "Confirmar",
 

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -7,6 +7,7 @@
   "noUsersFound": "(Nta bakoresha baraboneka)",
   "feedbackNameEmpty": "Nylyamubwire izina!",
   "feedbackWelcome": "Ikaze, {userName}!",
+  "feedbackError": "Habaye ikosa: {error}",
   "title_found_users": "Abakoresha Babonetse",
   "button_confirm": "Emeza",
 

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -7,6 +7,7 @@
   "noUsersFound": "(Hakuna watumiaji bado)",
   "feedbackNameEmpty": "Tafadhali weka jina!",
   "feedbackWelcome": "Karibu, {userName}!",
+  "feedbackError": "Hitilafu imetokea: {error}",
   "title_found_users": "Watumiaji Waliopatikana",
   "button_confirm": "Thibitisha",
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
         <!-- ユーザー入力フォーム -->
         <div class="input-form">
-            <input type="text" id="name-input" data-translate-key="placeholder_name_input" placeholder="なまえをいれてね">
+            <input type="text" id="name-input" data-translate-key-placeholder="namePlaceholder" placeholder="">
             <button id="confirm-button" data-translate-key="button_confirm">けってい</button>
         </div>
 

--- a/renderer.js
+++ b/renderer.js
@@ -25,7 +25,7 @@ function translateUI() {
 confirmButton.addEventListener('click', async () => {
     const userName = nameInput.value;
     if (!userName) {
-        feedbackText.textContent = 'なまえをいれてね！';
+        feedbackText.textContent = currentTranslation.feedbackNameEmpty;
         return;
     }
     handleLogin(userName);
@@ -47,11 +47,11 @@ async function handleLogin(userName) {
     const result = await window.electronAPI.loginOrCreateUser(userName);
 
     if (result.success) {
-        feedbackText.textContent = `ようこそ、${result.userName}さん！`;
+        feedbackText.textContent = currentTranslation.feedbackWelcome.replace('{userName}', result.userName);
         // ログイン成功後、メインメニューへ遷移
         window.electronAPI.navigateToMainMenu(result.userName);
     } else {
-        feedbackText.textContent = `エラーが発生しました: ${result.error}`;
+        feedbackText.textContent = currentTranslation.feedbackError.replace('{error}', result.error);
     }
 }
 
@@ -63,7 +63,7 @@ async function displayUsers() {
     userListDiv.innerHTML = ''; // 一旦リストを空にする
 
     if (users.length === 0) {
-        userListDiv.textContent = '（まだ誰もいないよ）';
+        userListDiv.textContent = currentTranslation.noUsersFound;
         return;
     }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded login feedback strings with translation lookups
- Translate name input placeholder via `data-translate-key-placeholder`
- Add missing `feedbackError` key to all language files

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68908d29cee48323a44b3afc80c067a3