### PR TITLE
Use translation strings for lobby connection messages

### DIFF
--- a/lobby.renderer.js
+++ b/lobby.renderer.js
@@ -47,11 +47,15 @@ window.electronAPI.onNetworkEvent((event, data) => {
 
     switch (event) {
         case 'client_connected':
-            hostStatus.textContent = `${data.userName} が接続しました！`;
+            hostStatus.textContent = currentTranslation.lobbyClientConnected
+                ? currentTranslation.lobbyClientConnected.replace('{clientName}', data.userName)
+                : `${data.userName} が接続しました！`;
             document.getElementById('start-match-button').disabled = false;
             break;
         case 'connected_to_host':
-            clientStatus.textContent = `${data.hostName} に接続しました。開始を待っています...`;
+            clientStatus.textContent = currentTranslation.lobbyConnectedToHost
+                ? currentTranslation.lobbyConnectedToHost.replace('{hostName}', data.hostName)
+                : `${data.hostName} に接続しました。開始を待っています...`;
             break;
         case 'start_game':
             window.electronAPI.navigateToGame(data.stageId);


### PR DESCRIPTION
## Summary
- Replace hardcoded lobby connection messages with translation strings and populate placeholders for user names.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890947de9dc8323b74a65091a679eb1