### PR TITLE
Use translations for stats labels

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -68,6 +68,10 @@
 
     "statsTitle": "Statistics",
     "scoreTransition": "Score Transition",
-    "keyStatsTitle": "Key Stats (Missed Keys)"
+    "keyStatsTitle": "Key Stats (Missed Keys)",
+    "stageOptionPrefix": "Stage ",
+    "mistakeUnit": " times",
+    "attemptLabel": "Attempt {n}",
+    "scoreLabel": "Score"
 
 }

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -69,5 +69,9 @@
 
   "statsTitle": "Estadísticas",
   "scoreTransition": "Transición de puntuación",
-  "keyStatsTitle": "Estadísticas de teclas (teclas falladas)"
+  "keyStatsTitle": "Estadísticas de teclas (teclas falladas)",
+  "stageOptionPrefix": "Nivel ",
+  "mistakeUnit": " veces",
+  "attemptLabel": "Intento {n}",
+  "scoreLabel": "Puntuación"
 }

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -69,6 +69,10 @@
   
     "statsTitle": "Statistiques",
     "scoreTransition": "Évolution du score",
-    "keyStatsTitle": "Statistiques des touches (touches ratées)"
+    "keyStatsTitle": "Statistiques des touches (touches ratées)",
+    "stageOptionPrefix": "Niveau ",
+    "mistakeUnit": " fois",
+    "attemptLabel": "Tentative {n}",
+    "scoreLabel": "Score"
   }
   

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -69,6 +69,10 @@
   
     "statsTitle": "統計",
     "scoreTransition": "スコア推移",
-    "keyStatsTitle": "キー統計（ミスタイプ）"
+    "keyStatsTitle": "キー統計（ミスタイプ）",
+    "stageOptionPrefix": "ステージ",
+    "mistakeUnit": "回",
+    "attemptLabel": "{n}回目",
+    "scoreLabel": "スコア"
   }
   

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -69,5 +69,9 @@
 
   "statsTitle": "Estatísticas",
   "scoreTransition": "Transição de Pontuação",
-  "keyStatsTitle": "Estatísticas de Teclas (Teclas Erradas)"
+  "keyStatsTitle": "Estatísticas de Teclas (Teclas Erradas)",
+  "stageOptionPrefix": "Fase ",
+  "mistakeUnit": " vezes",
+  "attemptLabel": "Tentativa {n}",
+  "scoreLabel": "Pontuação"
 }

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -69,5 +69,9 @@
 
   "statsTitle": "Imibare",
   "scoreTransition": "Imihindagurikire y’Amanota",
-  "keyStatsTitle": "Imibare y’Imfunguzo (Zibuze)"
+  "keyStatsTitle": "Imibare y’Imfunguzo (Zibuze)",
+  "stageOptionPrefix": "Urwego ",
+  "mistakeUnit": " inshuro",
+  "attemptLabel": "Igerageza {n}",
+  "scoreLabel": "Amanota"
 }

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -69,5 +69,9 @@
 
   "statsTitle": "Takwimu",
   "scoreTransition": "Mabadiliko ya Alama",
-  "keyStatsTitle": "Takwimu za Vifunguo (Vilivyokosewa)"
+  "keyStatsTitle": "Takwimu za Vifunguo (Vilivyokosewa)",
+  "stageOptionPrefix": "Hatua ",
+  "mistakeUnit": " mara",
+  "attemptLabel": "Jaribio {n}",
+  "scoreLabel": "Alama"
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded stage, attempt, and score labels in stats renderer with current translations
- Localize key stats, chart labels, and score dataset across all languages

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_6890944236108323839c8745ac6f8ae1