### PR TITLE
Build stage list from translation data

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -27,6 +27,7 @@
     "gameButtonQuit": "Quit",
     "OpponentProgress": "Opponent's Progress",
     "YourProgress": "Your Progress",
+    "comingSoon": "(Coming soon)",
     "stages": {
         "1": { "name": "Home Row Practice", "description": "Basic training" },
         "2": { "name": "All Keys Practice", "description": "Practice all keys" },

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -27,6 +27,7 @@
   "gameButtonQuit": "Salir",
   "OpponentProgress": "Progreso del oponente",
   "YourProgress": "Tu progreso",
+  "comingSoon": "(Próximamente)",
 
   "stages": {
     "1": { "name": "Práctica fila base", "description": "Entrenamiento básico" },

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -27,7 +27,8 @@
     "gameButtonQuit": "Quitter",
     "OpponentProgress": "Progression de l'adversaire",
     "YourProgress": "Votre progression",
-  
+    "comingSoon": "(Bientôt disponible)",
+
     "stages": {
       "1": { "name": "Entraînement rangée de base", "description": "Entraînement de base" },
       "2": { "name": "Entraînement toutes les touches", "description": "Pratiquer toutes les touches" },

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -27,7 +27,8 @@
     "gameButtonQuit": "終了",
     "OpponentProgress": "相手の進行状況",
     "YourProgress": "あなたの進行状況",
-  
+    "comingSoon": "（近日公開）",
+
     "stages": {
       "1": { "name": "ホームポジション練習", "description": "基本トレーニング" },
       "2": { "name": "全キー練習", "description": "すべてのキーを練習" },

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -27,6 +27,7 @@
   "gameButtonQuit": "Sair",
   "OpponentProgress": "Progresso do Oponente",
   "YourProgress": "Seu Progresso",
+  "comingSoon": "(Em breve)",
 
   "stages": {
     "1": { "name": "Treino da Linha Base", "description": "Treinamento básico" },

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -27,6 +27,7 @@
   "gameButtonQuit": "Sohoka",
   "OpponentProgress": "Iterambere ry'Uwo Mwahanganye",
   "YourProgress": "Iterambere Ryawe",
+  "comingSoon": "(Biraje vuba)",
 
   "stages": {
     "1": { "name": "Imyitozo ya Laini Y’Inyuma", "description": "Amahugurwa y’ibanze" },

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -27,6 +27,7 @@
   "gameButtonQuit": "Toka",
   "OpponentProgress": "Maendeleo ya Mpinzani",
   "YourProgress": "Maendeleo Yako",
+  "comingSoon": "(Hivi karibuni)",
 
   "stages": {
     "1": { "name": "Mazoezi ya Safu ya Kati", "description": "Mafunzo ya msingi" },

--- a/stageSelect.renderer.js
+++ b/stageSelect.renderer.js
@@ -1,18 +1,6 @@
 // stageSelect.renderer.js
 const stageGrid = document.querySelector('.stage-grid');
 
-// 要件定義に基づいたステージ情報
-const stages = [
-    { id: 1, name: 'ホームキー・ならし', description: '基本の練習' },
-    { id: 2, name: '全キー・ならし', description: 'すべてのキーの練習' },
-    { id: 3, name: '星降るホームキー', description: 'ホームキーの練習' },
-    { id: 4, name: '星降る全キー', description: 'すべてのキーの練習' },
-    { id: 5, name: '単語れんしゅう', description: '隕石を破壊せよ！' }, // 更新
-    { id: 6, name: '文章れんしゅう', description: '長文で隕石を破壊！' }, // 更新
-    { id: 7, name: '対戦：進捗レース', description: '対戦1' },
-    { id: 8, name: '対戦：早食いチャレンジ', description: '対戦2' },
-    { id: 9, name: '苦手キー復習', description: '（準備中）' },
-];
 
 let currentTranslation = {};
 
@@ -26,35 +14,6 @@ function translateUI() {
         if (currentTranslation[key]) el.placeholder = currentTranslation[key];
     });
 }
-// ステージ情報を元にボタンを生成
-stages.forEach(stage => {
-    const stageButton = document.createElement('button');
-    stageButton.className = 'stage-button';
-    // ステージが準備中なら 'disabled' クラスを追加
-    if (stage.description === '（準備中）') {
-        stageButton.classList.add('disabled');
-    }
-    
-    stageButton.innerHTML = `
-        <span class="stage-id">STAGE ${stage.id}</span>
-        <span class="stage-name">${stage.name}</span>
-        <span class="stage-description">${stage.description}</span>
-    `;
-
-    // 準備中のステージはクリックできないようにする
-    if (stage.description !== '（準備中）') {
-        stageButton.addEventListener('click', () => {
-            // ゲーム画面へ、選択したステージIDを渡して遷移
-            if (stage.id === 7 || stage.id === 8) {
-                window.electronAPI.navigateToLobby(stage.id); // lobbyへの遷移に変更
-            } else {
-                window.electronAPI.navigateToGame(stage.id);
-            }
-        });
-    }
-
-    stageGrid.appendChild(stageButton);
-});
 
 // (修正) ステージボタンを生成する関数
 function createStageButtons() {
@@ -63,22 +22,24 @@ function createStageButtons() {
     const stages = currentTranslation.stages;
     if (!stages) return;
 
-    for (const id in stages) {
-        const stage = stages[id];
+    const comingSoonText = currentTranslation.comingSoon;
+
+    for (const [id, stage] of Object.entries(stages)) {
         const stageButton = document.createElement('button');
         stageButton.className = 'stage-button';
-        
-        if (stage.description === '（準備中）' || stage.description === '(Coming soon)') {
+
+        const isComingSoon = stage.status === 'comingSoon' || stage.status === 'coming_soon' || stage.comingSoon === true || (comingSoonText && stage.description === comingSoonText);
+        if (isComingSoon) {
             stageButton.classList.add('disabled');
         }
-        
+
         stageButton.innerHTML = `
             <span class="stage-id">STAGE ${id}</span>
             <span class="stage-name">${stage.name}</span>
             <span class="stage-description">${stage.description}</span>
         `;
 
-        if (!stageButton.classList.contains('disabled')) {
+        if (!isComingSoon) {
             stageButton.addEventListener('click', () => {
                 const stageId = parseInt(id, 10);
                 if (stageId === 7 || stageId === 8) {


### PR DESCRIPTION
## Summary
- Remove static stage definitions in stage select renderer
- Generate stage buttons from currentTranslation.stages and disable buttons if marked coming soon via status flag or localized string
- Add localized `comingSoon` strings to language files

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68909446593883238cf36980c2eaf929