### PR TITLE
feat: add lobby connection translations

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -64,6 +64,8 @@
     "lobbyConnectButton": "Connect",
     "lobbyStatusWaiting": "Waiting for opponent...",
     "lobbyStatusConnected": "Connected! Waiting for the host to start the game.",
+    "lobbyClientConnected": "{{clientName}} connected",
+    "lobbyConnectedToHost": "Connected to host {{hostName}}",
     "lobbyStartButton": "Start Match",
 
     "statsTitle": "Statistics",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -65,6 +65,8 @@
   "lobbyConnectButton": "Conectar",
   "lobbyStatusWaiting": "Esperando al oponente...",
   "lobbyStatusConnected": "¡Conectado! Esperando a que el anfitrión inicie el juego.",
+  "lobbyClientConnected": "{{clientName}} se ha conectado",
+  "lobbyConnectedToHost": "Conectado al anfitrión {{hostName}}",
   "lobbyStartButton": "Iniciar partida",
 
   "statsTitle": "Estadísticas",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -65,6 +65,8 @@
     "lobbyConnectButton": "Connexion",
     "lobbyStatusWaiting": "En attente d’un adversaire...",
     "lobbyStatusConnected": "Connecté ! En attente du démarrage de la partie par l’hôte.",
+    "lobbyClientConnected": "{{clientName}} s'est connecté",
+    "lobbyConnectedToHost": "Connecté à l'hôte {{hostName}}",
     "lobbyStartButton": "Lancer la partie",
   
     "statsTitle": "Statistiques",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -65,6 +65,8 @@
     "lobbyConnectButton": "接続",
     "lobbyStatusWaiting": "対戦相手を待っています...",
     "lobbyStatusConnected": "接続完了！ホストの開始を待っています。",
+    "lobbyClientConnected": "{{clientName}} が接続しました",
+    "lobbyConnectedToHost": "ホスト {{hostName}} に接続しました",
     "lobbyStartButton": "試合開始",
   
     "statsTitle": "統計",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -65,6 +65,8 @@
   "lobbyConnectButton": "Conectar",
   "lobbyStatusWaiting": "Aguardando o oponente...",
   "lobbyStatusConnected": "Conectado! Aguardando o anfitrião iniciar o jogo.",
+  "lobbyClientConnected": "{{clientName}} se conectou",
+  "lobbyConnectedToHost": "Conectado ao anfitrião {{hostName}}",
   "lobbyStartButton": "Iniciar Partida",
 
   "statsTitle": "Estatísticas",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -65,6 +65,8 @@
   "lobbyConnectButton": "Huzaho",
   "lobbyStatusWaiting": "Gutegereje uwo muhanganye...",
   "lobbyStatusConnected": "Bihujwe! Tegereza ko umuyobozi atangiza umukino.",
+  "lobbyClientConnected": "{{clientName}} yahujwe",
+  "lobbyConnectedToHost": "Yahujwe n'umuyobozi {{hostName}}",
   "lobbyStartButton": "Tangiza Irushanwa",
 
   "statsTitle": "Imibare",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -65,6 +65,8 @@
   "lobbyConnectButton": "Unganisha",
   "lobbyStatusWaiting": "Inasubiri mpinzani...",
   "lobbyStatusConnected": "Umeunganishwa! Subiri mwenyeji aanze mchezo.",
+  "lobbyClientConnected": "{{clientName}} ameunganishwa",
+  "lobbyConnectedToHost": "Imeunganishwa na mwenyeji {{hostName}}",
   "lobbyStartButton": "Anza Mechi",
 
   "statsTitle": "Takwimu",


### PR DESCRIPTION
## Summary
- add lobby connection messages to English, Spanish, French, Japanese, Portuguese, Kinyarwanda, and Swahili locales

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890947d2aa0832399b04384ae26c5a5