### PR TITLE
feat: localize main process error dialog

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -8,6 +8,8 @@
     "feedbackNameEmpty": "Please enter a name!",
     "feedbackWelcome": "Welcome, {userName}!",
     "feedbackError": "An error occurred: {error}",
+    "errorTitle": "Error",
+    "userDataError": "An error occurred while processing user data.",
     "title_found_users": "Found Users",
     "button_confirm": "Confirm",
 

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -8,6 +8,8 @@
   "feedbackNameEmpty": "¡Por favor, ingresa un nombre!",
   "feedbackWelcome": "¡Bienvenido, {userName}!",
   "feedbackError": "Ocurrió un error: {error}",
+  "errorTitle": "Error",
+  "userDataError": "Se produjo un error al procesar los datos del usuario.",
   "title_found_users": "Usuarios encontrados",
   "button_confirm": "Confirmar",
 

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -8,6 +8,8 @@
     "feedbackNameEmpty": "Veuillez entrer un nom !",
     "feedbackWelcome": "Bienvenue, {userName} !",
     "feedbackError": "Une erreur s'est produite : {error}",
+    "errorTitle": "Erreur",
+    "userDataError": "Une erreur est survenue lors du traitement des données utilisateur.",
     "title_found_users": "Utilisateurs trouvés",
     "button_confirm": "Confirmer",
   

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -8,6 +8,8 @@
     "feedbackNameEmpty": "名前を入力してください！",
     "feedbackWelcome": "ようこそ、{userName}さん！",
     "feedbackError": "エラーが発生しました: {error}",
+    "errorTitle": "エラー",
+    "userDataError": "ユーザーデータの処理中にエラーが発生しました。",
     "title_found_users": "見つかったユーザー",
     "button_confirm": "確認",
   

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -8,6 +8,8 @@
   "feedbackNameEmpty": "Por favor, insira um nome!",
   "feedbackWelcome": "Bem-vindo, {userName}!",
   "feedbackError": "Ocorreu um erro: {error}",
+  "errorTitle": "Erro",
+  "userDataError": "Ocorreu um erro ao processar os dados do usuário.",
   "title_found_users": "Usuários encontrados",
   "button_confirm": "Confirmar",
 

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -8,6 +8,8 @@
   "feedbackNameEmpty": "Nylyamubwire izina!",
   "feedbackWelcome": "Ikaze, {userName}!",
   "feedbackError": "Habaye ikosa: {error}",
+  "errorTitle": "Ikosa",
+  "userDataError": "Habaye ikosa mu gutunganya amakuru y'umukoresha.",
   "title_found_users": "Abakoresha Babonetse",
   "button_confirm": "Emeza",
 

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -8,6 +8,8 @@
   "feedbackNameEmpty": "Tafadhali weka jina!",
   "feedbackWelcome": "Karibu, {userName}!",
   "feedbackError": "Hitilafu imetokea: {error}",
+  "errorTitle": "Hitilafu",
+  "userDataError": "Hitilafu imetokea wakati wa kuchakata data ya mtumiaji.",
   "title_found_users": "Watumiaji Waliopatikana",
   "button_confirm": "Thibitisha",
 


### PR DESCRIPTION
## Summary
- load and refresh current language translations in the main process
- use localized strings for user data errors
- add `errorTitle` and `userDataError` to every language file

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890980d42588323880d92902edb7a38