### PR TITLE
Add translatable titles across pages

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -18,6 +18,12 @@
 
     "stageSelectTitle": "Select a Stage",
 
+    "titleStageSelect": "Stage Select",
+    "titleGame": "Game",
+    "titleResult": "Game Result",
+    "titleLobby": "Versus Lobby",
+    "titleStats": "Statistics",
+
     "gameLabelTime": "TIME",
     "gameLabelScore": "SCORE",
     "gameLabelRemaining": "LEFT",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -18,6 +18,12 @@
 
   "stageSelectTitle": "Seleccionar nivel",
 
+  "titleStageSelect": "Seleccionar nivel",
+  "titleGame": "Juego",
+  "titleResult": "Resultado del juego",
+  "titleLobby": "Sala de Versus",
+  "titleStats": "Estadísticas",
+
   "gameLabelTime": "TIEMPO",
   "gameLabelScore": "PUNTOS",
   "gameLabelRemaining": "RESTANTE",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -17,6 +17,12 @@
     "menuSettings": "Paramètres",
   
     "stageSelectTitle": "Sélectionner un niveau",
+
+    "titleStageSelect": "Sélectionner un niveau",
+    "titleGame": "Jeu",
+    "titleResult": "Résultat du jeu",
+    "titleLobby": "Salon multijoueur",
+    "titleStats": "Statistiques",
   
     "gameLabelTime": "TEMPS",
     "gameLabelScore": "SCORE",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -17,6 +17,12 @@
     "menuSettings": "設定",
   
     "stageSelectTitle": "ステージ選択",
+
+    "titleStageSelect": "ステージ選択",
+    "titleGame": "ゲームプレイ",
+    "titleResult": "ゲーム結果",
+    "titleLobby": "対戦ロビー",
+    "titleStats": "統計データ",
   
     "gameLabelTime": "時間",
     "gameLabelScore": "スコア",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -18,6 +18,12 @@
 
   "stageSelectTitle": "Selecionar Fase",
 
+  "titleStageSelect": "Selecionar Fase",
+  "titleGame": "Jogo",
+  "titleResult": "Resultado do Jogo",
+  "titleLobby": "Sala de Versus",
+  "titleStats": "Estatísticas",
+
   "gameLabelTime": "TEMPO",
   "gameLabelScore": "PONTUAÇÃO",
   "gameLabelRemaining": "RESTANTES",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -18,6 +18,12 @@
 
   "stageSelectTitle": "Hitamo Urwego",
 
+  "titleStageSelect": "Hitamo Urwego",
+  "titleGame": "Umukino",
+  "titleResult": "Ibisubizo by'umukino",
+  "titleLobby": "Icyumba cya Versus",
+  "titleStats": "Imibare",
+
   "gameLabelTime": "IGIHE",
   "gameLabelScore": "AMANOTA",
   "gameLabelRemaining": "HASIGAYE",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -18,6 +18,12 @@
 
   "stageSelectTitle": "Chagua Hatua",
 
+  "titleStageSelect": "Chagua Hatua",
+  "titleGame": "Mchezo",
+  "titleResult": "Matokeo ya Mchezo",
+  "titleLobby": "Chumba cha Mchezo wa Versus",
+  "titleStats": "Takwimu",
+
   "gameLabelTime": "MUDA",
   "gameLabelScore": "ALAMA",
   "gameLabelRemaining": "ZILIZOBAKI",

--- a/game.html
+++ b/game.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>ゲームプレイ</title>
+    <title data-translate-key="titleGame">ゲームプレイ</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/lobby.html
+++ b/lobby.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>対戦ロビー</title>
+    <title data-translate-key="titleLobby">対戦ロビー</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/result.html
+++ b/result.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>ゲーム結果</title>
+    <title data-translate-key="titleResult">ゲーム結果</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -7,6 +7,18 @@ const backButton = document.getElementById('back-button');
 const chartCanvas = document.getElementById('score-chart');
 
 let lastResult = null;
+let currentTranslation = {};
+
+function translateUI() {
+    document.querySelectorAll('[data-translate-key]').forEach(el => {
+        const key = el.getAttribute('data-translate-key');
+        if (currentTranslation[key]) el.textContent = currentTranslation[key];
+    });
+    document.querySelectorAll('[data-translate-key-placeholder]').forEach(el => {
+        const key = el.getAttribute('data-translate-key-placeholder');
+        if (currentTranslation[key]) el.placeholder = currentTranslation[key];
+    });
+}
 
 // グラフと結果を表示するメインの関数
 async function displayResults() {
@@ -74,5 +86,10 @@ backButton.addEventListener('click', () => {
     window.electronAPI.navigateToMainMenu();
 });
 
-// 初期化
-displayResults();
+async function initialize() {
+    const settings = await window.electronAPI.getSettings();
+    currentTranslation = await window.electronAPI.getTranslation(settings.language);
+    translateUI();
+    await displayResults();
+}
+initialize();

--- a/stageSelect.html
+++ b/stageSelect.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>ステージ選択</title>
+    <title data-translate-key="titleStageSelect">ステージ選択</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/stats.html
+++ b/stats.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>統計データ</title>
+    <title data-translate-key="titleStats">統計データ</title>
     <link rel="stylesheet" href="style.css">
     <style>
         /* この画面専用のスタイル */


### PR DESCRIPTION
## Summary
- Add `data-translate-key` to titles on stage select, game, result, lobby and stats pages
- Provide matching title keys across all language JSON files
- Initialize translation logic in results renderer so the title updates dynamically

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890980e916083239a5997467b098127