### PR TITLE
Add main menu translation keys

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -11,6 +11,7 @@
     "title_found_users": "Found Users",
     "button_confirm": "Confirm",
 
+    "mainMenuTitle": "Main Menu",
     "mainMenuWelcome": "Welcome, {userName}!",
     "menuStart": "Start Game",
     "menuStats": "Statistics",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -11,6 +11,7 @@
   "title_found_users": "Usuarios encontrados",
   "button_confirm": "Confirmar",
 
+  "mainMenuTitle": "Menú Principal",
   "mainMenuWelcome": "¡Bienvenido, {userName}!",
   "menuStart": "Iniciar juego",
   "menuStats": "Estadísticas",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -10,7 +10,8 @@
     "feedbackError": "Une erreur s'est produite : {error}",
     "title_found_users": "Utilisateurs trouvés",
     "button_confirm": "Confirmer",
-  
+
+    "mainMenuTitle": "Menu Principal",
     "mainMenuWelcome": "Bienvenue, {userName} !",
     "menuStart": "Commencer le jeu",
     "menuStats": "Statistiques",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -10,7 +10,8 @@
     "feedbackError": "エラーが発生しました: {error}",
     "title_found_users": "見つかったユーザー",
     "button_confirm": "確認",
-  
+
+    "mainMenuTitle": "メインメニュー",
     "mainMenuWelcome": "ようこそ、{userName}さん！",
     "menuStart": "ゲーム開始",
     "menuStats": "統計",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -11,6 +11,7 @@
   "title_found_users": "Usuários encontrados",
   "button_confirm": "Confirmar",
 
+  "mainMenuTitle": "Menu Principal",
   "mainMenuWelcome": "Bem-vindo, {userName}!",
   "menuStart": "Iniciar Jogo",
   "menuStats": "Estatísticas",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -11,6 +11,7 @@
   "title_found_users": "Abakoresha Babonetse",
   "button_confirm": "Emeza",
 
+  "mainMenuTitle": "Menu Nyamukuru",
   "mainMenuWelcome": "Ikaze, {userName}!",
   "menuStart": "Tangiza Umukino",
   "menuStats": "Imibare",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -11,6 +11,7 @@
   "title_found_users": "Watumiaji Waliopatikana",
   "button_confirm": "Thibitisha",
 
+  "mainMenuTitle": "Menyu Kuu",
   "mainMenuWelcome": "Karibu, {userName}!",
   "menuStart": "Anza Mchezo",
   "menuStats": "Takwimu",

--- a/mainMenu.html
+++ b/mainMenu.html
@@ -2,14 +2,14 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>メインメニュー</title>
+    <title data-translate-key="mainMenuTitle">メインメニュー</title>
     <!-- ユーザー選択画面と同じスタイルシートを再利用 -->
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="container">
         <!-- ユーザー名が表示されるエリア -->
-        <h1 id="welcome-message" >ようこそ！</h1>
+        <h1 id="welcome-message" data-translate-key="mainMenuWelcome">ようこそ！</h1>
         
         <div class="menu-buttons">
             <button class="menu-button" id="start-button" data-translate-key="menuStart">ゲームスタート</button>


### PR DESCRIPTION
## Summary
- localize main menu title and welcome message
- add `mainMenuTitle` entries for all languages

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6890980c731c8323854267e49047116a