### PR TITLE
fix welcome message username placeholder

### DIFF
--- a/mainMenu.renderer.js
+++ b/mainMenu.renderer.js
@@ -2,6 +2,7 @@
 const welcomeMessage = document.getElementById('welcome-message');
 
 let currentTranslation = {};
+let currentUserName = '';
 
 function translateUI() {
     document.querySelectorAll('[data-translate-key]').forEach(el => {
@@ -12,18 +13,18 @@ function translateUI() {
         const key = el.getAttribute('data-translate-key-placeholder');
         if (currentTranslation[key]) el.placeholder = currentTranslation[key];
     });
+    updateWelcomeMessage();
+}
+
+function updateWelcomeMessage() {
+    const messageTemplate = currentTranslation.mainMenuWelcome || "{userName}さん、ようこそ！";
+    const formattedMessage = messageTemplate.replace('{userName}', currentUserName);
+    welcomeMessage.textContent = formattedMessage;
 }
 
 window.electronAPI.onSetUser((userName) => {
-    // welcomeMessage.textContent = `${userName}さん、ようこそ！`;
-
-    // 翻訳データからテンプレート文字列を取得
-    const messageTemplate = currentTranslation.mainMenuWelcome || "{userName}さん、ようこそ！";
-    console.log(messageTemplate)
-    // プレースホルダーを実際のユーザー名に置き換え
-    const formattedMessage = messageTemplate.replace('{userName}', userName);
-    welcomeMessage.textContent = formattedMessage;
-    
+    currentUserName = userName;
+    updateWelcomeMessage();
 });
 
 // ゲームスタートボタンの処理をステージ選択画面への遷移に変更


### PR DESCRIPTION
## Summary
- ensure the main menu replaces `{userName}` with the actual user name after translation is applied
- store current user name and refresh the welcome message whenever translations update

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68909ca5a0f4832395296ad74b501da1