### PR TITLE
Enable Stage 9 in stage select

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -47,7 +47,7 @@
         "6": { "name": "Sentence Practice", "description": "Destroy with long sentences!" },
         "7": { "name": "VS: Progress Race", "description": "Race to the finish!" },
         "8": { "name": "VS: Score Attack", "description": "Compete for score!" },
-        "9": { "name": "Weak Key Review", "description": "(Coming soon)" }
+        "9": { "name": "Weak Key Review", "description": "Review keys you struggle with" }
       },
     "alertClearTitle": "CLEAR!",
     "alertGameOverTitle": "GAME OVER!",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -48,7 +48,7 @@
     "6": { "name": "Práctica de frases", "description": "¡Destruye con frases largas!" },
     "7": { "name": "VS: Carrera de progreso", "description": "¡Corre hasta la meta!" },
     "8": { "name": "VS: Ataque de puntuación", "description": "¡Compite por puntos!" },
-    "9": { "name": "Revisión de teclas débiles", "description": "(Próximamente)" }
+    "9": { "name": "Revisión de teclas débiles", "description": "Repasa las teclas que te cuestan" }
   },
 
   "alertClearTitle": "¡COMPLETADO!",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -48,7 +48,7 @@
       "6": { "name": "Pratique des phrases", "description": "Détruisez avec des phrases !" },
       "7": { "name": "VS : Course de progression", "description": "Faites la course jusqu’à la fin !" },
       "8": { "name": "VS : Attaque de score", "description": "Faites le meilleur score !" },
-      "9": { "name": "Révision des touches faibles", "description": "(Bientôt disponible)" }
+      "9": { "name": "Révision des touches faibles", "description": "Révisez les touches qui vous posent problème" }
     },
   
     "alertClearTitle": "RÉUSSI !",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -48,7 +48,7 @@
       "6": { "name": "文章練習", "description": "長い文章で破壊せよ！" },
       "7": { "name": "対戦：進行レース", "description": "ゴールまで競争！" },
       "8": { "name": "対戦：スコアアタック", "description": "スコアを競え！" },
-      "9": { "name": "弱点キー復習", "description": "（近日公開）" }
+      "9": { "name": "弱点キー復習", "description": "苦手キーを復習するステージ" }
     },
   
     "alertClearTitle": "クリア！",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -48,7 +48,7 @@
     "6": { "name": "Prática de Frases", "description": "Destrua com frases longas!" },
     "7": { "name": "VS: Corrida de Progresso", "description": "Corra até o final!" },
     "8": { "name": "VS: Ataque de Pontuação", "description": "Compita pela pontuação!" },
-    "9": { "name": "Revisão de Teclas Fracas", "description": "(Em breve)" }
+    "9": { "name": "Revisão de Teclas Fracas", "description": "Revise as teclas que você tem dificuldade" }
   },
 
   "alertClearTitle": "CONCLUÍDO!",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -48,7 +48,7 @@
     "6": { "name": "Imyitozo y’Ibyo Kuvuga", "description": "Senyera interuro ndende!" },
     "7": { "name": "VS: Isiganwa ry’Iterambere", "description": "Irushanwa kugeza ku iherezo!" },
     "8": { "name": "VS: Kurushanwa ku Manota", "description": "Kurushanwa ku manota!" },
-    "9": { "name": "Gusubiramo Imfunguzo Ziciriritse", "description": "(Biraje vuba)" }
+    "9": { "name": "Gusubiramo Imfunguzo Ziciriritse", "description": "Subiramo imfunguzo zikugora" }
   },
 
   "alertClearTitle": "BIRARANGIYE!",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -48,7 +48,7 @@
     "6": { "name": "Mazoezi ya Sentensi", "description": "Haribu kwa sentensi ndefu!" },
     "7": { "name": "VS: Mbio za Maendeleo", "description": "Kimbia hadi mwisho!" },
     "8": { "name": "VS: Mashindano ya Alama", "description": "Shindana kwa alama!" },
-    "9": { "name": "Mapitio ya Vifunguo Dhaifu", "description": "(Hivi karibuni)" }
+    "9": { "name": "Mapitio ya Vifunguo Dhaifu", "description": "Pitia vitufe vinavyokuletea shida" }
   },
 
   "alertClearTitle": "IMEKAMILIKA!",


### PR DESCRIPTION
## Summary
- localize Stage 9 descriptions across all language files

## Testing
- `npm test` (fails: Missing script)
- `node - <<'NODE'
const translation = require('./assets/lang/en.json');
const comingSoonText = translation.comingSoon;
const stage9 = translation.stages["9"];
const isComingSoon = stage9.status === 'comingSoon' || stage9.status === 'coming_soon' || stage9.comingSoon === true || (comingSoonText && stage9.description === comingSoonText);
console.log('Stage9 isComingSoon:', isComingSoon);
if (!isComingSoon) {
  const stageId = 9;
  if (stageId === 7 || stageId === 8) {
    console.log('navigateToLobby', stageId);
  } else {
    console.log('navigateToGame', stageId);
  }
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6890bee63758832387c6b7b41ab92545