### PR TITLE
chore: use Electron 22.3.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "devDependencies": {
     "chart.js": "^4.4.2",
-    "electron": "^31.0.1",
+    "electron": "22.3.27",
     "electron-builder": "^24.13.3"
   },
   "build": {


### PR DESCRIPTION
## Summary
- use Electron 22.3.27 to retain Windows 7 compatibility

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/electron/-/electron-22.3.27.tgz)*
- `npm run build:win32` *(fails: Get https://github.com/electron/electron/releases/download/v31.7.7/electron-v31.7.7-win32-ia32.zip: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6890c923cb24832396b18ffe28f8e29f