### PR TITLE
Block sensitive Electron permissions

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // main.js
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, session } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const net = require('net'); // Node.jsのnetモジュールをインポート
@@ -156,6 +156,13 @@ ipcMain.handle('get-stats-data', () => {
 });
 
 app.whenReady().then(() => {
+    session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+        if (["media", "geolocation", "notifications"].includes(permission)) {
+            return callback(false);
+        }
+        callback(true);
+    });
+
     createWindow();
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) createWindow();


### PR DESCRIPTION
## Summary
- include Electron session module
- deny media, geolocation, and notification permission requests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890dcebbe3883239beb3cb47b64456f