### PR TITLE
feat: allow language selection on first launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,21 @@
     <div class="container">
         <h1 data-translate-key="userSelectTitle">ユーザーをえらんでね</h1>
         <p class="description" data-translate-key="userSelectDescription">なまえをいれるか、したからえらんでね</p>
-        
+
+        <!-- Language selection (shown on first launch) -->
+        <div class="input-form" id="language-select-container" style="display: none;">
+            <label for="language-select" data-translate-key="settingLanguage">言語</label>
+            <select id="language-select" class="custom-select">
+                <option value="en">English</option>
+                <option value="ja">日本語</option>
+                <option value="fr">Français</option>
+                <option value="es">Español</option>
+                <option value="pt">Português</option>
+                <option value="sw">Kiswahili</option>
+                <option value="rw">Ikinyarwanda</option>
+            </select>
+        </div>
+
 
         <!-- ユーザー入力フォーム -->
         <div class="input-form">

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ const settingsFilePath = path.join(app.getPath('userData'), 'settings.json');
 const defaultSettings = {
     bgm: true,
     sfx: true,
-    language: 'ja',
+    language: 'en',
     layout: 'qwerty',
 };
 

--- a/renderer.js
+++ b/renderer.js
@@ -5,6 +5,8 @@ const nameInput = document.getElementById('name-input');
 const confirmButton = document.getElementById('confirm-button');
 const feedbackText = document.getElementById('feedback-text');
 const userListDiv = document.getElementById('user-list');
+const languageSelectContainer = document.getElementById('language-select-container');
+const languageSelect = document.getElementById('language-select');
 
 let currentTranslation = {};
 
@@ -38,6 +40,15 @@ nameInput.addEventListener('keydown', (event) => {
     }
 });
 
+// 言語選択が変更されたときの処理
+languageSelect.addEventListener('change', async () => {
+    const newLang = languageSelect.value;
+    await window.electronAPI.saveSettings({ language: newLang });
+    currentTranslation = await window.electronAPI.getTranslation(newLang);
+    translateUI();
+    displayUsers();
+});
+
 
 // --- 関数の定義 ---
 
@@ -59,11 +70,13 @@ async function handleLogin(userName) {
 async function displayUsers() {
     // preload.js経由でmain.jsの処理を呼び出す
     const users = await window.electronAPI.getUsers();
-    
+
     userListDiv.innerHTML = ''; // 一旦リストを空にする
+    languageSelectContainer.style.display = 'none';
 
     if (users.length === 0) {
         userListDiv.textContent = currentTranslation.noUsersFound;
+        languageSelectContainer.style.display = 'flex';
         return;
     }
 
@@ -83,6 +96,7 @@ async function displayUsers() {
 async function initialize() {
     const settings = await window.electronAPI.getSettings();
     currentTranslation = await window.electronAPI.getTranslation(settings.language);
+    languageSelect.value = settings.language;
     translateUI();
     displayUsers();
 }


### PR DESCRIPTION
## Summary
- default app language is now English
- show language selector when no user data exists

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6890e575bd2883239c4f624a9509e75b