### PR TITLE
feat: add point-based victory to stage 7

### DIFF
--- a/game.html
+++ b/game.html
@@ -36,11 +36,11 @@
             </div>
 
             <div id="opponent-info-container" class="opponent-info-container" style="display: none;">
-                <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/60)</h2>
+                <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/40)</h2>
                 <div class="progress-container">
                     <div id="my-progress-bar" class="progress-bar my-bar"></div>
                 </div>
-                <h2 class="opponent-label" data-translate-key="OpponentProgress" style="margin-top: 15px;">対戦相手の進捗 (<span id="opponent-word-count">0</span>/60)</h2>
+                <h2 class="opponent-label" data-translate-key="OpponentProgress" style="margin-top: 15px;">対戦相手の進捗 (<span id="opponent-word-count">0</span>/40)</h2>
                 <div class="progress-container">
                     <div id="opponent-progress-bar" class="progress-bar opponent-bar"></div>
                 </div>

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -94,7 +94,7 @@ const STAGE_CONFIG = {
         title: "対戦：進捗レース",
         gameMode: 'race', // 新しいゲームモードとして 'race' を定義
         wordList: [],     // 文章リストを使用 (ステージ6のものを流用)
-        questionLimit: 1, // 1つの文章の早さを競う
+        questionLimit: 40, // 40ポイント先取で勝利
     },
     8: {
         id: 8,
@@ -149,9 +149,12 @@ let singleChar_highlightedKeyElement = null;
 let singleChar_consecutiveCorrectAnswers = 0;
 let singleChar_isKeyboardVisible = true;
 
-// (追加) レース用の進捗管理変数
-let myWordsCleared = 0;
-let opponentWordsCleared = 0;
+// (更新) レース用の進捗・スコア管理変数
+let raceWordIndex = 0; // 現在の単語インデックス
+let myScore = 0;
+let opponentScore = 0;
+let raceConsecutivePerfect = 0; // 連続ミスなし数
+let raceWordHasMistake = false; // 現在の単語でミスが発生したか
 
 // --- 関数定義 ---
 function createKeyboard() {
@@ -389,16 +392,28 @@ function handleKeyPress(event) {
             updateWordAsteroidDisplay();
 
             if (word_typedWord === word_currentWord) {
-                myWordsCleared++;
-                myProgressBar.style.width = `${(myWordsCleared / 60) * 100}%`;
-                myWordCount.textContent = myWordsCleared;
-                
-                // 相手にクリアを通知
-                window.electronAPI.sendMessage({ type: 'word_cleared' });
-                
+                // ポイント計算
+                let gained = raceWordHasMistake ? 1 : 3;
+                myScore += gained;
+                if (!raceWordHasMistake) {
+                    raceConsecutivePerfect++;
+                    if (raceConsecutivePerfect % 3 === 0) {
+                        myScore += 3; // ボーナス
+                    }
+                } else {
+                    raceConsecutivePerfect = 0;
+                }
+
+                // UI更新
+                myProgressBar.style.width = `${(myScore / 40) * 100}%`;
+                myWordCount.textContent = myScore;
+
+                // 相手にスコアを通知
+                window.electronAPI.sendMessage({ type: 'score_update', value: myScore });
+
                 // 勝敗判定
                 if (checkRaceWinCondition()) return;
-                
+
                 // 次の単語へ
                 setNextRaceWord();
             }
@@ -412,7 +427,7 @@ function handleKeyPress(event) {
             if (expectedKey) {
                 keyMistakeStats[expectedKey] = (keyMistakeStats[expectedKey] || 0) + 1;
             }
-            
+            raceWordHasMistake = true;
         }
     } else if (currentConfig.gameMode === 'scoreAttack') {
         // --- ここからステージ8 (scoreAttack) 専用の新しい処理 ---
@@ -732,12 +747,14 @@ function startGame() {
         lastSpawnTime = 0;
         fallingStars_gameLoop();
     } else if (currentConfig.gameMode === 'race') { // この else if を追加
-        myWordsCleared = 0;
-        opponentWordsCleared = 0;
+        raceWordIndex = 0;
+        myScore = 0;
+        opponentScore = 0;
+        raceConsecutivePerfect = 0;
         word_typedWord = '';
         currentConfig.timeLimit = 120; // 制限時間を設定
         timerDisplay.textContent = currentConfig.timeLimit;
-        
+
         // UIの初期化
         opponentInfoContainer.style.display = 'block';
         myProgressBar.style.width = '0%';
@@ -782,10 +799,10 @@ function startCountdown() {
 
 function listenToOpponent() {
     window.electronAPI.onNetworkData(data => {
-        if (data.type === 'word_cleared') {
-            opponentWordsCleared++;
-            opponentProgressBar.style.width = `${(opponentWordsCleared / 60) * 100}%`;
-            opponentWordCount.textContent = opponentWordsCleared;
+        if (data.type === 'score_update' && currentConfig.gameMode === 'race') {
+            opponentScore = data.value;
+            opponentProgressBar.style.width = `${(opponentScore / 40) * 100}%`;
+            opponentWordCount.textContent = opponentScore;
             checkRaceWinCondition();
         }
         if (data.type === 'opponent_quit') {
@@ -793,14 +810,7 @@ function listenToOpponent() {
             gameOver(currentTranslation.gameOverOpponentDisconnected);
             return; // 以降の処理は不要
         }
-        if (data.type === 'progress_update' && currentConfig.gameMode === 'race') {
-            // 相手の進捗バーを更新
-            opponentProgressBar.style.width = `${data.value * 100}%`;
-            // 相手が100%になったら敗北処理
-            if (data.value >= 1) {
-                gameOver(currentTranslation.gameOverOpponentFinished);
-            }
-        } else if (data.type === 'score_update' && currentConfig.gameMode === 'scoreAttack') {
+        if (data.type === 'score_update' && currentConfig.gameMode === 'scoreAttack') {
             // 相手のスコアを更新
             opponentScoreDisplay.textContent = data.value;
         } else if (data.type === 'game_clear') {
@@ -811,34 +821,35 @@ function listenToOpponent() {
 }
 
 function setNextRaceWord() {
-    if (myWordsCleared < 60) {
-        word_currentWord = currentConfig.wordList[myWordsCleared];
+    if (raceWordIndex < currentConfig.wordList.length) {
+        word_currentWord = currentConfig.wordList[raceWordIndex];
+        raceWordIndex++;
         word_typedWord = '';
+        raceWordHasMistake = false;
         updateWordAsteroidDisplay(); // 表示更新ロジックは流用
     }
 }
 
 // (追加) 勝敗判定を行う関数
 function checkRaceWinCondition() {
-    if ((myWordsCleared + opponentWordsCleared) >= 60) {
-        // 合計60単語に達した場合
+    if (myScore >= 40 || opponentScore >= 40) {
         judgeRaceResult();
         return true;
     }
     return false;
 }
 
-// (追加) 最終的な勝敗を判定してゲームを終了する関数
+// (更新) 最終的な勝敗を判定してゲームを終了する関数
 function judgeRaceResult() {
     let msg = "";
-    if (myWordsCleared > opponentWordsCleared) {
-        msg = `勝利！ (${myWordsCleared} vs ${opponentWordsCleared})`;
-    } else if (myWordsCleared < opponentWordsCleared) {
-        msg = `敗北... (${myWordsCleared} vs ${opponentWordsCleared})`;
+    if (myScore > opponentScore) {
+        msg = `勝利！ (${myScore} vs ${opponentScore})`;
+    } else if (myScore < opponentScore) {
+        msg = `敗北... (${myScore} vs ${opponentScore})`;
     } else {
         msg = currentTranslation.gameOverTie
-            .replace('{myCount}', myWordsCleared)
-            .replace('{opponentCount}', opponentWordsCleared);
+            .replace('{myCount}', myScore)
+            .replace('{opponentCount}', opponentScore);
     }
     stopGame(msg);
 }


### PR DESCRIPTION
## Summary
- switch stage 7 to a 40-point race
- award 3 points for perfect words, 1 point otherwise, with bonus after 3 perfect words
- update UI to show point progress

## Testing
- `npm test` *(fails: Missing script)*
- `node --check game.renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_689287d976a48323bd0006c4c4ee46b9