### PR TITLE
Remove progress bar remnants from race mode

### DIFF
--- a/game.html
+++ b/game.html
@@ -37,12 +37,12 @@
 
             <div id="opponent-info-container" class="opponent-info-container" style="display: none;">
                 <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/40)</h2>
-                <div class="progress-container">
-                    <div id="my-progress-bar" class="progress-bar my-bar"></div>
+                <div class="race-track">
+                    <div id="my-character" class="race-character my-character"></div>
                 </div>
                 <h2 class="opponent-label" data-translate-key="OpponentProgress" style="margin-top: 15px;">対戦相手の進捗 (<span id="opponent-word-count">0</span>/40)</h2>
-                <div class="progress-container">
-                    <div id="opponent-progress-bar" class="progress-bar opponent-bar"></div>
+                <div class="race-track">
+                    <div id="opponent-character" class="race-character opponent-character"></div>
                 </div>
             </div>
 

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -25,9 +25,8 @@ const comboDisplay = document.getElementById('combo-display');
 
 
 const opponentInfoContainer = document.getElementById('opponent-info-container');
-const opponentProgressContainer = document.getElementById('opponent-progress-container');
-const opponentProgressBar = document.getElementById('opponent-progress-bar');
-const myProgressBar = document.getElementById('my-progress-bar');
+const myCharacter = document.getElementById('my-character');
+const opponentCharacter = document.getElementById('opponent-character');
 const myWordCount = document.getElementById('my-word-count');
 const opponentWordCount = document.getElementById('opponent-word-count');
 
@@ -405,7 +404,7 @@ function handleKeyPress(event) {
                 }
 
                 // UI更新
-                myProgressBar.style.width = `${(myScore / 40) * 100}%`;
+                myCharacter.style.left = `${(myScore / 40) * 100}%`;
                 myWordCount.textContent = myScore;
 
                 // 相手にスコアを通知
@@ -757,8 +756,8 @@ function startGame() {
 
         // UIの初期化
         opponentInfoContainer.style.display = 'block';
-        myProgressBar.style.width = '0%';
-        opponentProgressBar.style.width = '0%';
+        myCharacter.style.left = '0%';
+        opponentCharacter.style.left = '0%';
         myWordCount.textContent = '0';
         opponentWordCount.textContent = '0';
 
@@ -801,7 +800,7 @@ function listenToOpponent() {
     window.electronAPI.onNetworkData(data => {
         if (data.type === 'score_update' && currentConfig.gameMode === 'race') {
             opponentScore = data.value;
-            opponentProgressBar.style.width = `${(opponentScore / 40) * 100}%`;
+            opponentCharacter.style.left = `${(opponentScore / 40) * 100}%`;
             opponentWordCount.textContent = opponentScore;
             checkRaceWinCondition();
         }
@@ -930,10 +929,9 @@ async function initialize() {
     questionText.style.display = 'none';
     if (currentConfig.gameMode === 'race' || currentConfig.gameMode === 'scoreAttack') {
         opponentInfoContainer.style.display = 'block';
-        if (currentConfig.gameMode === 'race') {
-            opponentProgressBar.style.display = 'block';
-        } else {
-            document.getElementById('opponent-score-container').style.display = 'block';
+        if (currentConfig.gameMode === 'scoreAttack') {
+            const scoreContainer = document.getElementById('opponent-score-container');
+            if (scoreContainer) scoreContainer.style.display = 'block';
         }
         showQuestionElements();
         keyboardLayoutDiv.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -267,34 +267,35 @@ input:checked + .slider:before {
     border-bottom: none; /* h2のデフォルトスタイルを上書き */
 }
 
-/* プログレスバーの背景（トラック） */
-.progress-container {
+/* レーストラックとキャラクター */
+.race-track {
+    position: relative;
     width: 100%;
     height: 30px;
     background-color: rgba(0, 0, 0, 0.3);
     border-radius: 15px;
     border: 2px solid rgba(255, 255, 255, 0.2);
-    overflow: hidden; /* 角丸を維持するため */
+    overflow: hidden;
 }
 
-/* プログレスバー本体 */
-.progress-bar {
-    width: 0%; /* JavaScriptでこの幅を操作します */
-    height: 100%;
+.race-character {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0%;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    transition: left 0.2s ease-out;
+}
+
+.race-character.my-character {
     background: linear-gradient(90deg, #81d4fa, #29b6f6);
-    border-radius: 13px; /* 親要素のborder分を考慮 */
-    transition: width 0.2s ease-out; /* 幅の変化を滑らかに見せるアニメーション */
     box-shadow: 0 0 10px #81d4fa;
 }
 
-/* プログレスバーの色の使い分け */
-.progress-bar.my-bar {
-    background: linear-gradient(90deg, #81d4fa, #29b6f6); /* 青系 */
-    box-shadow: 0 0 10px #81d4fa;
-}
-
-.progress-bar.opponent-bar {
-    background: linear-gradient(90deg, #f48fb1, #f06292); /* ピンク系 */
+.race-character.opponent-character {
+    background: linear-gradient(90deg, #f48fb1, #f06292);
     box-shadow: 0 0 10px #f48fb1;
 }
 


### PR DESCRIPTION
## Summary
- Replace race progress bars with character-based tracks in game UI
- Track positions updated instead of width for player and opponent
- Drop obsolete progress-bar styling and logic

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689367ca84688323b30032affb4c10e0