### PR TITLE
Add opponent score display section

### DIFF
--- a/game.html
+++ b/game.html
@@ -44,6 +44,10 @@
                 <div class="progress-container">
                     <div id="opponent-progress-bar" class="progress-bar opponent-bar"></div>
                 </div>
+                <div id="opponent-score-container" class="opponent-score-container" style="display: none;">
+                    <h2 class="opponent-label" data-translate-key="OpponentScore">対戦相手のスコア</h2>
+                    <div id="opponentScoreDisplay" class="opponent-score-display">0</div>
+                </div>
             </div>
 
         </div>

--- a/style.css
+++ b/style.css
@@ -267,6 +267,27 @@ input:checked + .slider:before {
     border-bottom: none; /* h2のデフォルトスタイルを上書き */
 }
 
+/* スコア表示用コンテナ */
+.opponent-score-container {
+    width: 100%;
+    margin-top: 15px;
+    text-align: left;
+}
+
+.opponent-score-display {
+    width: 100%;
+    height: 30px;
+    background-color: rgba(0, 0, 0, 0.3);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 15px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5em;
+    font-weight: bold;
+    color: #f48fb1;
+}
+
 /* プログレスバーの背景（トラック） */
 .progress-container {
     width: 100%;


### PR DESCRIPTION
## Summary
- add opponent score container and display to game page
- style opponent score section for consistency with existing UI

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689367cb64188323ae7eff9bff60af9f