### PR TITLE
Remove opponent progress bar logic

### DIFF
--- a/game.html
+++ b/game.html
@@ -37,13 +37,7 @@
 
             <div id="opponent-info-container" class="opponent-info-container" style="display: none;">
                 <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/40)</h2>
-                <div class="progress-container">
-                    <div id="my-progress-bar" class="progress-bar my-bar"></div>
-                </div>
                 <h2 class="opponent-label" data-translate-key="OpponentProgress" style="margin-top: 15px;">対戦相手の進捗 (<span id="opponent-word-count">0</span>/40)</h2>
-                <div class="progress-container">
-                    <div id="opponent-progress-bar" class="progress-bar opponent-bar"></div>
-                </div>
             </div>
 
         </div>

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -25,9 +25,6 @@ const comboDisplay = document.getElementById('combo-display');
 
 
 const opponentInfoContainer = document.getElementById('opponent-info-container');
-const opponentProgressContainer = document.getElementById('opponent-progress-container');
-const opponentProgressBar = document.getElementById('opponent-progress-bar');
-const myProgressBar = document.getElementById('my-progress-bar');
 const myWordCount = document.getElementById('my-word-count');
 const opponentWordCount = document.getElementById('opponent-word-count');
 
@@ -405,7 +402,6 @@ function handleKeyPress(event) {
                 }
 
                 // UI更新
-                myProgressBar.style.width = `${(myScore / 40) * 100}%`;
                 myWordCount.textContent = myScore;
 
                 // 相手にスコアを通知
@@ -757,8 +753,6 @@ function startGame() {
 
         // UIの初期化
         opponentInfoContainer.style.display = 'block';
-        myProgressBar.style.width = '0%';
-        opponentProgressBar.style.width = '0%';
         myWordCount.textContent = '0';
         opponentWordCount.textContent = '0';
 
@@ -801,7 +795,6 @@ function listenToOpponent() {
     window.electronAPI.onNetworkData(data => {
         if (data.type === 'score_update' && currentConfig.gameMode === 'race') {
             opponentScore = data.value;
-            opponentProgressBar.style.width = `${(opponentScore / 40) * 100}%`;
             opponentWordCount.textContent = opponentScore;
             checkRaceWinCondition();
         }
@@ -930,9 +923,7 @@ async function initialize() {
     questionText.style.display = 'none';
     if (currentConfig.gameMode === 'race' || currentConfig.gameMode === 'scoreAttack') {
         opponentInfoContainer.style.display = 'block';
-        if (currentConfig.gameMode === 'race') {
-            opponentProgressBar.style.display = 'block';
-        } else {
+        if (currentConfig.gameMode === 'scoreAttack') {
             document.getElementById('opponent-score-container').style.display = 'block';
         }
         showQuestionElements();


### PR DESCRIPTION
## Summary
- Drop opponent progress bar elements from game UI
- Simplify race initialization to only show relevant opponent info and question areas
- Remove progress bar state updates during races

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689367ce3b8483238df71a5713a96f08