### PR TITLE
Add opponent score container and guard access

### DIFF
--- a/game.html
+++ b/game.html
@@ -35,6 +35,11 @@
                 <span id="bonus-display" class="info-value">x1.0</span>
             </div>
 
+            <div class="info-box" id="opponent-score-container" style="display: none;">
+                <span class="info-label" data-translate-key="OpponentScore">相手のスコア</span>
+                <span id="opponent-score-display" class="info-value">0</span>
+            </div>
+
             <div id="opponent-info-container" class="opponent-info-container" style="display: none;">
                 <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/40)</h2>
                 <div class="progress-container">

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -30,6 +30,8 @@ const opponentProgressBar = document.getElementById('opponent-progress-bar');
 const myProgressBar = document.getElementById('my-progress-bar');
 const myWordCount = document.getElementById('my-word-count');
 const opponentWordCount = document.getElementById('opponent-word-count');
+const opponentScoreContainer = document.getElementById('opponent-score-container');
+const opponentScoreDisplay = document.getElementById('opponent-score-display');
 
 let CURRENT_LAYOUT = []; // (New!) 現在のキーボードレイアウトを保持
 let currentTranslation = {};
@@ -697,7 +699,7 @@ function gameOver(customMessage) { // customMessageを受け取れるように�
     // (追加) 早食いチャレンジの勝敗判定
     if (currentConfig.gameMode === 'scoreAttack' && timeLeft <= 0) {
         const myScore = score;
-        const opponentScore = parseInt(opponentScoreDisplay.textContent, 10);
+        const opponentScore = opponentScoreDisplay ? parseInt(opponentScoreDisplay.textContent, 10) : 0;
         if (myScore > opponentScore) {
             customMessage = `勝利！ (${myScore} vs ${opponentScore})`;
         } else if (myScore < opponentScore) {
@@ -812,7 +814,9 @@ function listenToOpponent() {
         }
         if (data.type === 'score_update' && currentConfig.gameMode === 'scoreAttack') {
             // 相手のスコアを更新
-            opponentScoreDisplay.textContent = data.value;
+            if (opponentScoreDisplay) {
+                opponentScoreDisplay.textContent = data.value;
+            }
         } else if (data.type === 'game_clear') {
             // 相手がクリアした場合（進捗レース用）
             gameOver(currentTranslation.gameOverOpponentFinished);
@@ -933,7 +937,9 @@ async function initialize() {
         if (currentConfig.gameMode === 'race') {
             opponentProgressBar.style.display = 'block';
         } else {
-            document.getElementById('opponent-score-container').style.display = 'block';
+            if (opponentScoreContainer) {
+                opponentScoreContainer.style.display = 'block';
+            }
         }
         showQuestionElements();
         keyboardLayoutDiv.style.display = 'none';


### PR DESCRIPTION
## Summary
- Add missing opponent score display container to game screen
- Reference new opponent score elements and guard access with null checks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689367cfed4c83238a42d090f4e51ef0