### PR TITLE
Fix Stage 7 race word list looping

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -858,15 +858,17 @@ function listenToOpponent() {
 }
 
 function setNextRaceWord() {
-    if (raceWordIndex < currentConfig.wordList.length) {
-        word_currentWord = currentConfig.wordList[raceWordIndex];
-        raceWordIndex++;
-        word_typedWord = '';
-        raceWordHasMistake = false;
-        // (New!) 日本語の場合はローマ字入力を初期化
-        prepareRomaji(word_currentWord);
-        updateWordAsteroidDisplay(); // 表示更新ロジックは流用
+    if (!currentConfig.wordList || currentConfig.wordList.length === 0) return;
+    if (raceWordIndex >= currentConfig.wordList.length) {
+        raceWordIndex = 0; // 単語リストをループ
     }
+    word_currentWord = currentConfig.wordList[raceWordIndex];
+    raceWordIndex++;
+    word_typedWord = '';
+    raceWordHasMistake = false;
+    // (New!) 日本語の場合はローマ字入力を初期化
+    prepareRomaji(word_currentWord);
+    updateWordAsteroidDisplay(); // 表示更新ロジックは流用
 }
 
 // (追加) 勝敗判定を行う関数

--- a/main.js
+++ b/main.js
@@ -404,14 +404,24 @@ ipcMain.handle('send-message', (event, message) => {
     // ゲーム開始リクエストはホストのみ
     if (isHost && message.type === 'start_game_request') {
         // (修正) ステージ7の場合、単語リストを作成・保持する
-            if (currentStageId === 7) {
+        if (currentStageId === 7) {
             const lang = loadSettings().language;
             const wordsFilePath = getAssetPath('words', `${lang}.json`);
             if (fs.existsSync(wordsFilePath)) {
                 const allWords = JSON.parse(fs.readFileSync(wordsFilePath, 'utf-8'));
                 const wordPool = allWords.stage5_words || []; // ステージ5の単語を流用
-                // シャッフルして60単語を抽出
-                currentRaceWordList = wordPool.sort(() => 0.5 - Math.random()).slice(0, 60);
+                const shuffled = [...wordPool].sort(() => 0.5 - Math.random());
+                if (shuffled.length < 60) {
+                    const looped = [];
+                    while (looped.length < 60) {
+                        looped.push(...shuffled);
+                    }
+                    currentRaceWordList = looped.slice(0, 60);
+                } else {
+                    currentRaceWordList = shuffled; // 60語以上なら全て使用
+                }
+            } else {
+                currentRaceWordList = [];
             }
         }
         const startGameMessage = JSON.stringify({ type: 'start_game', stageId: currentStageId });


### PR DESCRIPTION
## Summary
- ensure Stage 7 generates a shuffled word list and loops when fewer than 60 words
- loop race word list on the renderer so words never run out

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895af2ea1f483238c61c8e2d7f0cff0