### PR TITLE
Use question limit for stage 7 win condition

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -455,7 +455,7 @@ function handleKeyPress(event) {
                 }
 
                 // UI更新
-                myProgressBar.style.width = `${(myScore / 60) * 100}%`;
+                myProgressBar.style.width = `${(myScore / currentConfig.questionLimit) * 100}%`;
                 myWordCount.textContent = myScore;
 
                 // 相手にスコアを通知
@@ -838,7 +838,7 @@ function listenToOpponent() {
     window.electronAPI.onNetworkData(data => {
         if (data.type === 'score_update' && currentConfig.gameMode === 'race') {
             opponentScore = data.value;
-            opponentProgressBar.style.width = `${(opponentScore / 60) * 100}%`;
+            opponentProgressBar.style.width = `${(opponentScore / currentConfig.questionLimit) * 100}%`;
             opponentWordCount.textContent = opponentScore;
             checkRaceWinCondition();
         }
@@ -873,8 +873,8 @@ function setNextRaceWord() {
 
 // (追加) 勝敗判定を行う関数
 function checkRaceWinCondition() {
-    if (myScore >= 60 || opponentScore >= 60) {
-        // 合計60単語に達した場合
+    if (myScore >= currentConfig.questionLimit || opponentScore >= currentConfig.questionLimit) {
+        // 合計 questionLimit 単語に達した場合
         judgeRaceResult();
         return true;
     }


### PR DESCRIPTION
## Summary
- Use configured question limit instead of hard-coded 60 for progress and win condition in stage 7 race mode.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b1cefa148323a7de8f82071d95e9