### PR TITLE
feat: allow user deletion

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -3,6 +3,8 @@
     "userSelectDescription": "Enter your name or select from below",
     "namePlaceholder": "Enter name...",
     "confirmButton": "Confirm",
+    "userDeleteButton": "Delete",
+    "confirmUserDelete": "Delete user \"{userName}\"?",
     "foundUsers": "Found Users",
     "noUsersFound": "(No users yet)",
     "feedbackNameEmpty": "Please enter a name!",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -3,6 +3,8 @@
   "userSelectDescription": "Ingresa tu nombre o selecciona uno de abajo",
   "namePlaceholder": "Ingresa nombre...",
   "confirmButton": "Confirmar",
+  "userDeleteButton": "Eliminar",
+  "confirmUserDelete": "¿Eliminar al usuario \"{userName}\"?",
   "foundUsers": "Usuarios encontrados",
   "noUsersFound": "(Aún no hay usuarios)",
   "feedbackNameEmpty": "¡Por favor, ingresa un nombre!",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -3,6 +3,8 @@
     "userSelectDescription": "Entrez votre nom ou sélectionnez ci-dessous",
     "namePlaceholder": "Entrez le nom...",
     "confirmButton": "Confirmer",
+    "userDeleteButton": "Supprimer",
+    "confirmUserDelete": "Supprimer l'utilisateur \"{userName}\" ?",
     "foundUsers": "Utilisateurs trouvés",
     "noUsersFound": "(Aucun utilisateur pour le moment)",
     "feedbackNameEmpty": "Veuillez entrer un nom !",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -3,6 +3,8 @@
     "userSelectDescription": "名前を入力するか、以下から選んでください",
     "namePlaceholder": "名前を入力...",
     "confirmButton": "確認",
+    "userDeleteButton": "削除",
+    "confirmUserDelete": "ユーザー「{userName}」を削除しますか？",
     "foundUsers": "見つかったユーザー",
     "noUsersFound": "（ユーザーがまだいません）",
     "feedbackNameEmpty": "名前を入力してください！",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -3,6 +3,8 @@
   "userSelectDescription": "Digite seu nome ou selecione abaixo",
   "namePlaceholder": "Digite o nome...",
   "confirmButton": "Confirmar",
+  "userDeleteButton": "Excluir",
+  "confirmUserDelete": "Excluir o usuário \"{userName}\"?",
   "foundUsers": "Usuários encontrados",
   "noUsersFound": "(Nenhum usuário ainda)",
   "feedbackNameEmpty": "Por favor, insira um nome!",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -3,6 +3,8 @@
   "userSelectDescription": "Andika izina ryawe cyangwa uhitemo hasi",
   "namePlaceholder": "Andika izina...",
   "confirmButton": "Emeza",
+  "userDeleteButton": "Siba",
+  "confirmUserDelete": "Ushaka gusiba umukoresha \"{userName}\"?",
   "foundUsers": "Abakoresha Babonetse",
   "noUsersFound": "(Nta bakoresha baraboneka)",
   "feedbackNameEmpty": "Nylyamubwire izina!",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -3,6 +3,8 @@
   "userSelectDescription": "Weka jina lako au chagua kutoka hapa chini",
   "namePlaceholder": "Weka jina...",
   "confirmButton": "Thibitisha",
+  "userDeleteButton": "Futa",
+  "confirmUserDelete": "Futa mtumiaji \"{userName}\"?",
   "foundUsers": "Watumiaji Waliopatikana",
   "noUsersFound": "(Hakuna watumiaji bado)",
   "feedbackNameEmpty": "Tafadhali weka jina!",

--- a/main.js
+++ b/main.js
@@ -185,6 +185,22 @@ ipcMain.handle('get-users', async () => {
         .map(file => path.parse(file).name);
 });
 
+ipcMain.handle('delete-user', async (event, userName) => {
+    try {
+        const filePath = path.join(saveDir, `${userName}.json`);
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+        }
+        if (currentUser === userName) {
+            currentUser = null;
+        }
+        return { success: true };
+    } catch (error) {
+        console.error('ユーザーの削除に失敗しました:', error);
+        return { success: false, error: error.message };
+    }
+});
+
 ipcMain.handle('save-settings', (event, settings) => {
     return saveSettings(settings);
 });

--- a/preload.js
+++ b/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // ユーザー選択画面で使うAPI
     getUsers: () => ipcRenderer.invoke('get-users'),
     loginOrCreateUser: (userName) => ipcRenderer.invoke('login-or-create-user', userName),
+    deleteUser: (userName) => ipcRenderer.invoke('delete-user', userName),
     onSetUser: (callback) => ipcRenderer.on('set-user', (event, userName) => callback(userName)),
 
     // 画面遷移で使うAPI

--- a/renderer.js
+++ b/renderer.js
@@ -68,14 +68,31 @@ async function displayUsers() {
     }
 
     users.forEach(user => {
+        const entryDiv = document.createElement('div');
+        entryDiv.className = 'user-entry';
+
         const userButton = document.createElement('button');
         userButton.textContent = user;
         userButton.className = 'user-button';
-        // 既存ユーザーのボタンが押されたら、その名前でログイン
         userButton.addEventListener('click', () => {
             handleLogin(user);
         });
-        userListDiv.appendChild(userButton);
+
+        const deleteButton = document.createElement('button');
+        deleteButton.textContent = currentTranslation.userDeleteButton;
+        deleteButton.className = 'user-delete-button';
+        deleteButton.addEventListener('click', async (e) => {
+            e.stopPropagation();
+            const msg = currentTranslation.confirmUserDelete.replace('{userName}', user);
+            if (confirm(msg)) {
+                await window.electronAPI.deleteUser(user);
+                displayUsers();
+            }
+        });
+
+        entryDiv.appendChild(userButton);
+        entryDiv.appendChild(deleteButton);
+        userListDiv.appendChild(entryDiv);
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -47,6 +47,9 @@ h2 { color: #8d6e63; border-bottom: 2px dashed #ffccbc; padding-bottom: 5px; }
 #user-list { margin-top: 10px; display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
 .user-button { font-family: 'Mochiy Pop One', sans-serif; background-color: #a1887f; color: white; border: none; padding: 8px 15px; border-radius: 8px; cursor: pointer; transition: background-color 0.3s; }
 .user-button:hover { background-color: #5d4037; }
+.user-entry { display: flex; align-items: center; gap: 5px; }
+.user-delete-button { font-family: 'Mochiy Pop One', sans-serif; background-color: #e57373; color: white; border: none; padding: 4px 8px; border-radius: 8px; cursor: pointer; font-size: 0.8em; transition: background-color 0.3s; }
+.user-delete-button:hover { background-color: #d32f2f; }
 
 /* --- メインメニュー / ステージ選択画面 --- */
 .menu-buttons { margin-top: 40px; display: flex; flex-direction: column; gap: 20px; }


### PR DESCRIPTION
## Summary
- add ipc handler to delete user data files and reset current user
- expose deleteUser to renderers and render delete buttons in user list
- translate and style new delete actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "const fs=require('fs');const p='assets/lang';fs.readdirSync(p).forEach(f=>{JSON.parse(fs.readFileSync(p+'/'+f,'utf8'));});console.log('lang ok');"`


------
https://chatgpt.com/codex/tasks/task_e_6898c1bbaa2483238814105b40cce6a4