### PR TITLE
Add clear history option for user stats

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -87,6 +87,8 @@
     "statsTitle": "Statistics",
     "scoreTransition": "Score Transition",
     "keyStatsTitle": "Key Stats (Missed Keys)",
+    "clearHistoryButton": "Clear History",
+    "confirmClearHistory": "Are you sure you want to clear your history?",
     "stageOptionPrefix": "Stage ",
     "mistakeUnit": " times",
     "attemptLabel": "Attempt {n}",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -88,6 +88,8 @@
   "statsTitle": "Estadísticas",
   "scoreTransition": "Transición de puntuación",
   "keyStatsTitle": "Estadísticas de teclas (teclas falladas)",
+  "clearHistoryButton": "Borrar historial",
+  "confirmClearHistory": "¿Seguro que quieres borrar tu historial?",
   "stageOptionPrefix": "Nivel ",
   "mistakeUnit": " veces",
   "attemptLabel": "Intento {n}",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -88,6 +88,8 @@
     "statsTitle": "Statistiques",
     "scoreTransition": "Évolution du score",
     "keyStatsTitle": "Statistiques des touches (touches ratées)",
+    "clearHistoryButton": "Effacer l'historique",
+    "confirmClearHistory": "Êtes-vous sûr de vouloir effacer votre historique ?",
     "stageOptionPrefix": "Niveau ",
     "mistakeUnit": " fois",
     "attemptLabel": "Tentative {n}",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -88,6 +88,8 @@
     "statsTitle": "統計",
     "scoreTransition": "スコア推移",
     "keyStatsTitle": "キー統計（ミスタイプ）",
+    "clearHistoryButton": "履歴をクリア",
+    "confirmClearHistory": "本当に履歴をクリアしますか？",
     "stageOptionPrefix": "ステージ",
     "mistakeUnit": "回",
     "attemptLabel": "{n}回目",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -88,6 +88,8 @@
   "statsTitle": "Estatísticas",
   "scoreTransition": "Transição de Pontuação",
   "keyStatsTitle": "Estatísticas de Teclas (Teclas Erradas)",
+  "clearHistoryButton": "Limpar histórico",
+  "confirmClearHistory": "Tem certeza de que deseja limpar seu histórico?",
   "stageOptionPrefix": "Fase ",
   "mistakeUnit": " vezes",
   "attemptLabel": "Tentativa {n}",

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -88,6 +88,8 @@
   "statsTitle": "Imibare",
   "scoreTransition": "Imihindagurikire y’Amanota",
   "keyStatsTitle": "Imibare y’Imfunguzo (Zibuze)",
+  "clearHistoryButton": "Siba Amateka",
+  "confirmClearHistory": "Uremeza ko ushaka gusiba amateka yawe?",
   "stageOptionPrefix": "Urwego ",
   "mistakeUnit": " inshuro",
   "attemptLabel": "Igerageza {n}",

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -88,6 +88,8 @@
   "statsTitle": "Takwimu",
   "scoreTransition": "Mabadiliko ya Alama",
   "keyStatsTitle": "Takwimu za Vifunguo (Vilivyokosewa)",
+  "clearHistoryButton": "Futa Historia",
+  "confirmClearHistory": "Je, una uhakika unataka kufuta historia yako?",
   "stageOptionPrefix": "Hatua ",
   "mistakeUnit": " mara",
   "attemptLabel": "Jaribio {n}",

--- a/main.js
+++ b/main.js
@@ -161,6 +161,23 @@ ipcMain.handle('get-stats-data', () => {
     return loadUserData(currentUser);
 });
 
+// ユーザーデータの履歴をクリアするIPCハンドラ
+ipcMain.handle('clear-user-history', () => {
+    if (!currentUser) {
+        return { success: false, error: 'No user logged in' };
+    }
+    try {
+        const userData = loadUserData(currentUser) || {};
+        userData.scoreHistory = {};
+        userData.keyStats = {};
+        saveUserData(currentUser, userData);
+        return { success: true };
+    } catch (error) {
+        console.error('Failed to clear user history:', error);
+        return { success: false, error: error.message };
+    }
+});
+
 app.whenReady().then(() => {
     createWindow();
     app.on('activate', () => {

--- a/preload.js
+++ b/preload.js
@@ -30,9 +30,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
     // ゲーム画面で使うAPI (New!)
     getCurrentStageId: () => ipcRenderer.invoke('get-current-stage-id'),
-    getRaceWordList: () => ipcRenderer.invoke('get-race-word-list'), 
+    getRaceWordList: () => ipcRenderer.invoke('get-race-word-list'),
     saveGameResult: (result) => ipcRenderer.send('save-game-result', result),
     getStatsData: () => ipcRenderer.invoke('get-stats-data'),
+    clearUserHistory: () => ipcRenderer.invoke('clear-user-history'),
 
     // --- ネットワークAPI ---
     startServer: () => ipcRenderer.invoke('start-server'),

--- a/stats.html
+++ b/stats.html
@@ -31,6 +31,7 @@
                 <div id="key-stats-grid" class="key-stats-grid"></div>
             </div>
         </div>
+        <button class="menu-button" data-translate-key="clearHistoryButton" id="clear-history-button">履歴をクリア</button>
         <button class="menu-button" data-translate-key="backButton" id="back-button">もどる</button>
     </div>
     <script src="./node_modules/chart.js/dist/chart.umd.js"></script>

--- a/stats.renderer.js
+++ b/stats.renderer.js
@@ -1,4 +1,5 @@
 const backButton = document.getElementById('back-button');
+const clearHistoryButton = document.getElementById('clear-history-button');
 const stageSelect = document.getElementById('stage-select');
 const keyStatsGrid = document.getElementById('key-stats-grid');
 const chartCanvas = document.getElementById('score-chart');
@@ -99,6 +100,16 @@ stageSelect.addEventListener('change', () => {
 
 backButton.addEventListener('click', () => {
     window.electronAPI.navigateToMainMenu();
+});
+
+clearHistoryButton.addEventListener('click', async () => {
+    const message = currentTranslation.confirmClearHistory || 'Are you sure you want to clear your history?';
+    if (confirm(message)) {
+        await window.electronAPI.clearUserHistory();
+        statsData = await window.electronAPI.getStatsData();
+        renderKeyStats();
+        renderChart(stageSelect.value);
+    }
 });
 
 initialize();


### PR DESCRIPTION
## Summary
- Add `clear-user-history` IPC handler to wipe current user's score history and key stats
- Expose `clearUserHistory` in preload and wire up new Clear History button in stats screen
- Provide translations for new Clear History UI strings across all languages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c1ba9b90832386d4e57883ab7ddd