### PR TITLE
Focus input after removing users

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -86,7 +86,9 @@ async function displayUsers() {
             const msg = currentTranslation.confirmUserDelete.replace('{userName}', user);
             if (confirm(msg)) {
                 await window.electronAPI.deleteUser(user);
-                displayUsers();
+                await displayUsers();
+                nameInput.value = '';
+                nameInput.focus();
             }
         });
 
@@ -101,6 +103,6 @@ async function initialize() {
     const settings = await window.electronAPI.getSettings();
     currentTranslation = await window.electronAPI.getTranslation(settings.language);
     translateUI();
-    displayUsers();
+    await displayUsers();
 }
 initialize();


### PR DESCRIPTION
## Summary
- Ensure user list refresh completes and input field is cleared and focused after a user is deleted
- Wait for user list display during initialization to avoid async race

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c6b3b0f88323adef86daf6c39d58