### PR TITLE
Replace alert and confirm with modal dialogs

### DIFF
--- a/game.html
+++ b/game.html
@@ -86,6 +86,7 @@
     <audio id="explosion-audio" src="./assets/audio/explosion.mp3"></audio> <!-- 爆発音 -->
 
     <script src="romaji.js"></script>
+    <script src="modal.js"></script>
     <script src="game.renderer.js"></script>
 </body>
 </html>

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -706,12 +706,12 @@ function handleKeyPress(event) {
 }
 
 // --- ゲームフロー関数 ---
-function stopGame(message) {
+async function stopGame(message) {
     isPlaying = false;
     cancelAnimationFrame(gameLoopId);
     if (settings.bgm) bgmAudio.pause();
     clearInterval(timerInterval);
-    if (message) alert(message);
+    if (message) await showModalAlert(message);
     window.electronAPI.navigateToMainMenu();
 }
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     </div>
 
     <!-- 画面のロジックを記述したJavaScriptファイルを読み込む -->
+    <script src="modal.js"></script>
     <script src="index.renderer.js"></script>
 </body>
 </html>

--- a/index.renderer.js
+++ b/index.renderer.js
@@ -84,7 +84,7 @@ async function displayUsers() {
         deleteButton.addEventListener('click', async (e) => {
             e.stopPropagation();
             const msg = currentTranslation.confirmUserDelete.replace('{userName}', user);
-            if (confirm(msg)) {
+            if (await showModalConfirm(msg)) {
                 await window.electronAPI.deleteUser(user);
                 setTimeout(() => {
                     nameInput.value = ''; // 入力欄をクリア

--- a/modal.js
+++ b/modal.js
@@ -1,0 +1,45 @@
+function showModal(message, showCancel) {
+    return new Promise((resolve) => {
+        const dialog = document.createElement('dialog');
+        dialog.classList.add('modal-dialog');
+
+        const p = document.createElement('p');
+        p.textContent = message;
+        dialog.appendChild(p);
+
+        const buttons = document.createElement('div');
+        buttons.className = 'modal-buttons';
+
+        const okButton = document.createElement('button');
+        okButton.textContent = 'OK';
+        okButton.addEventListener('click', () => dialog.close('ok'));
+        buttons.appendChild(okButton);
+
+        if (showCancel) {
+            const cancelButton = document.createElement('button');
+            cancelButton.textContent = 'Cancel';
+            cancelButton.addEventListener('click', () => dialog.close('cancel'));
+            buttons.appendChild(cancelButton);
+        }
+
+        dialog.appendChild(buttons);
+        document.body.appendChild(dialog);
+        dialog.addEventListener('close', () => {
+            const result = dialog.returnValue === 'ok';
+            dialog.remove();
+            resolve(result);
+        });
+        dialog.showModal();
+    });
+}
+
+function showModalAlert(message) {
+    return showModal(message, false).then(() => {});
+}
+
+function showModalConfirm(message) {
+    return showModal(message, true);
+}
+
+window.showModalAlert = showModalAlert;
+window.showModalConfirm = showModalConfirm;

--- a/stats.html
+++ b/stats.html
@@ -35,6 +35,7 @@
         <button class="menu-button" data-translate-key="backButton" id="back-button">もどる</button>
     </div>
     <script src="./node_modules/chart.js/dist/chart.umd.js"></script>
+    <script src="modal.js"></script>
     <script src="stats.renderer.js"></script>
 </body>
 </html>

--- a/stats.renderer.js
+++ b/stats.renderer.js
@@ -104,7 +104,7 @@ backButton.addEventListener('click', () => {
 
 clearHistoryButton.addEventListener('click', async () => {
     const message = currentTranslation.confirmClearHistory || 'Are you sure you want to clear your history?';
-    if (confirm(message)) {
+    if (await showModalConfirm(message)) {
         await window.electronAPI.clearUserHistory();
         statsData = await window.electronAPI.getStatsData();
         renderKeyStats();

--- a/style.css
+++ b/style.css
@@ -328,3 +328,24 @@ textarea#credits-textarea::-webkit-scrollbar-track {
     background-color: rgba(0, 0, 0, 0.1); /* スクロールバーの背景色 */
     border-radius: 5px;
 }
+/* Modal dialog */
+dialog.modal-dialog {
+    border: none;
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 400px;
+}
+
+dialog.modal-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.modal-buttons {
+    margin-top: 15px;
+    text-align: center;
+}
+
+.modal-buttons button {
+    margin: 0 5px;
+}
+


### PR DESCRIPTION
## Summary
- add reusable modal dialog utilities for alerts and confirms
- style dialog appearance and load modal script on pages
- swap legacy alert/confirm calls to await modal interactions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898d45f8458832396b2dfc9e0c966b3