### PR TITLE
fix: ensure typing mistakes are saved

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -193,7 +193,7 @@ function singleChar_clearHighlight() {
     }
 }
 
-function saveResultAndExit(message) {
+async function saveResultAndExit(message) {
     const finalScore = score + (timeLeft > 0 ? timeLeft * 100 : 0);
 
     const resultData = {
@@ -203,7 +203,7 @@ function saveResultAndExit(message) {
         endMessage: message // 終了メッセージも結果画面に渡す
     };
 
-    window.electronAPI.saveGameResult(resultData);
+    await window.electronAPI.saveGameResult(resultData);
     window.electronAPI.navigateToResult(resultData);
 }
 

--- a/main.js
+++ b/main.js
@@ -126,13 +126,13 @@ const createWindow = () => {
 
 
 // ゲーム結果を保存するIPCハンドラ
-ipcMain.on('save-game-result', (event, result) => {
+ipcMain.handle('save-game-result', async (event, result) => {
     console.log('レンダラーからゲーム結果を受信しました:', result);
     console.log('現在のユーザー:', currentUser);
-    if (!currentUser) return;
+    if (!currentUser) return { success: false };
 
     const userData = loadUserData(currentUser);
-    if (!userData) return;
+    if (!userData) return { success: false };
 
     // スコア履歴の初期化
     if (!userData.scoreHistory) userData.scoreHistory = {};
@@ -153,6 +153,7 @@ ipcMain.on('save-game-result', (event, result) => {
     }
 
     saveUserData(currentUser, userData);
+    return { success: true };
 });
 
 // 統計データを取得するIPCハンドラ

--- a/preload.js
+++ b/preload.js
@@ -32,7 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // ゲーム画面で使うAPI (New!)
     getCurrentStageId: () => ipcRenderer.invoke('get-current-stage-id'),
     getRaceWordList: () => ipcRenderer.invoke('get-race-word-list'),
-    saveGameResult: (result) => ipcRenderer.send('save-game-result', result),
+    saveGameResult: (result) => ipcRenderer.invoke('save-game-result', result),
     getStatsData: () => ipcRenderer.invoke('get-stats-data'),
     clearUserHistory: () => ipcRenderer.invoke('clear-user-history'),
 


### PR DESCRIPTION
## Summary
- guarantee game results, including key mistakes, are saved before leaving the game screen
- expose `saveGameResult` as an IPC invoke API
- wait for save completion before navigating to result screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898de018a9c8323b7197c0e14ff90a1