### PR TITLE
Display score breakdown and chart on result screen

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -194,13 +194,16 @@ function singleChar_clearHighlight() {
 }
 
 async function saveResultAndExit(message) {
-    const finalScore = score + (timeLeft > 0 ? timeLeft * 100 : 0);
+    const timeBonus = timeLeft > 0 ? timeLeft * 100 : 0;
+    const totalScore = score + timeBonus;
 
     const resultData = {
         stageId: currentConfig.id,
-        score: finalScore,
+        score: score,
+        timeBonus: timeBonus,
+        totalScore: totalScore,
         mistakes: keyMistakeStats,
-        endMessage: message // 終了メッセージも結果画面に渡す
+        endMessage: message
     };
 
     await window.electronAPI.saveGameResult(resultData);
@@ -716,18 +719,8 @@ async function stopGame(message) {
 }
 
 function gameClear(customMessage) {
-    // if (customMessage) {
-    //     stopGame(customMessage);
-    //     return;
-    // }
-    const timeBonus = timeLeft * 100;
-    const finalScore = score + timeBonus;
-    const message = `${currentTranslation.alertClearTitle}\n` +
-                  `${currentTranslation.alertScore}: ${score}\n` +
-                  `${currentTranslation.alertTimeBonus}: ${timeBonus}\n` +
-                  `${currentTranslation.alertTotalScore}: ${finalScore}`;
-
-    saveResultAndExit(message); // 新しい共通関数を呼び出す
+    const message = customMessage || currentTranslation.alertClearTitle;
+    saveResultAndExit(message);
 }
 
 function gameOver(customMessage) { // customMessageを受け取れるように変更
@@ -746,8 +739,8 @@ function gameOver(customMessage) { // customMessageを受け取れるように�
         judgeRaceResult();
         return;
     }
-    const message = customMessage || `${currentTranslation.alertTimeUp} ${currentTranslation.alertScore}: ${score}`;
-    saveResultAndExit(message); // 新しい共通関数を呼び出す
+    const message = customMessage || currentTranslation.alertTimeUp;
+    saveResultAndExit(message);
 
 }
 
@@ -1014,3 +1007,4 @@ async function initialize() {
     startCountdown();
 }
 initialize();
+

--- a/main.js
+++ b/main.js
@@ -139,9 +139,9 @@ ipcMain.handle('save-game-result', async (event, result) => {
     const stageKey = `stage${result.stageId}`;
     if (!userData.scoreHistory[stageKey]) userData.scoreHistory[stageKey] = [];
 
-    // 新しいスコアを追加
+    // 新しいスコアを追加（トータルスコアを保存）
     userData.scoreHistory[stageKey].push({
-        score: result.score,
+        score: result.totalScore || result.score,
         date: new Date().toISOString()
     });
 
@@ -491,3 +491,4 @@ ipcMain.on('close-connection', () => {
     }
     isHost = false; // Reset flag
 });
+

--- a/result.html
+++ b/result.html
@@ -11,13 +11,12 @@
         
         <div class="result-summary">
             <p data-translate-key="alertScore">今回のスコア</p>
-
-
-            <h2 id="final-score">0</h2>
-            <h2 id="final-score">0</h2>
+            <h2 id="score">0</h2>
+            <p data-translate-key="alertTimeBonus">タイムボーナス</p>
+            <h2 id="time-bonus">0</h2>
             <hr>
             <p data-translate-key="alertTotalScore">合計スコア</p>
-            <h2 id="final-score">0</h2>
+            <h2 id="total-score">0</h2>
         </div>
 
         <div class="chart-container" style="width: 100%; height: 300px; margin-top: 20px;">

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -1,6 +1,7 @@
 const endMessageEl = document.getElementById('end-message');
-const finalScoreEl = document.getElementById('final-score');
+const scoreEl = document.getElementById('score');
 const timeBonusEl = document.getElementById('time-bonus');
+const totalScoreEl = document.getElementById('total-score');
 
 const retryButton = document.getElementById('retry-button');
 const backButton = document.getElementById('back-button');
@@ -33,8 +34,9 @@ async function displayResults() {
 
     // 今回の結果を表示
     endMessageEl.textContent = lastResult.endMessage;
-    finalScoreEl.textContent = lastResult.score.toLocaleString();
-    timeBonusEl.textContent = `タイムボーナス: ${lastResult.timeBonus.toLocaleString()}`;
+    scoreEl.textContent = lastResult.score.toLocaleString();
+    timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
+    totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
     
     // グラフを描画
     const stageKey = `stage${lastResult.stageId}`;


### PR DESCRIPTION
## Summary
- Show separate score, time bonus and total on the result page
- Save detailed score data and render graph for the played stage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898ef8e51e483239a3b4821509b8ddc