### PR TITLE
Use animal images for race progress bar

### DIFF
--- a/game.html
+++ b/game.html
@@ -38,11 +38,11 @@
             <div id="opponent-info-container" class="opponent-info-container" style="display: none;">
                 <h2 class="opponent-label" data-translate-key="YourProgress">あなたの進捗 (<span id="my-word-count">0</span>/40)</h2>
                 <div class="progress-container">
-                    <div id="my-progress-bar" class="progress-bar my-bar"></div>
+                    <img id="my-progress-animal" class="progress-animal" src="./assets/img/fox_normal.png" alt="Player 1">
                 </div>
                 <h2 class="opponent-label" data-translate-key="OpponentProgress" style="margin-top: 15px;">対戦相手の進捗 (<span id="opponent-word-count">0</span>/40)</h2>
                 <div class="progress-container">
-                    <div id="opponent-progress-bar" class="progress-bar opponent-bar"></div>
+                    <img id="opponent-progress-animal" class="progress-animal" src="./assets/img/camel_normal.png" alt="Player 2">
                 </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -271,16 +271,28 @@ input:checked + .slider:before {
 }
 
 /* プログレスバーの背景（トラック） */
+/* プログレスバーの背景（トラック） */
 .progress-container {
     width: 100%;
-    height: 30px;
+    height: 80px;
     background-color: rgba(0, 0, 0, 0.3);
     border-radius: 15px;
     border: 2px solid rgba(255, 255, 255, 0.2);
     overflow: hidden; /* 角丸を維持するため */
+    position: relative;
 }
 
-/* プログレスバー本体 */
+/* 走る動物 */
+.progress-animal {
+    position: absolute;
+    top: 50%;
+    left: 0%;
+    transform: translate(-50%, -50%);
+    height: 60px;
+    transition: left 0.2s ease-out;
+}
+
+/* 旧スタイルのプログレスバーを保持（他ステージ互換用） */
 .progress-bar {
     width: 0%; /* JavaScriptでこの幅を操作します */
     height: 100%;


### PR DESCRIPTION
## Summary
- Replace stage 7 progress bars with fox and camel images
- Animate animals based on typing progress and show mistake/combo states
- Add CSS for animal track styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898fc18dd208323a0d7ffff9a2ea610