### PR TITLE
feat: add layout-specific accent maps

### DIFF
--- a/assets/layouts/abnt2.json
+++ b/assets/layouts/abnt2.json
@@ -40,9 +40,23 @@
   "practiceKeys": {
     "homeRow": ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ç"],
     "alphabet": [
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
       "ç", "á", "à", "ã", "â", "é", "ê", "í", "ó", "ô", "õ", "ú", "ü"
     ]
+  },
+  "accentMap": {
+    "á": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "à": { "accentChar": "`", "keyChar": "`", "needsShift": false },
+    "ã": { "accentChar": "~", "keyChar": "~", "needsShift": false },
+    "â": { "accentChar": "^", "keyChar": "~", "needsShift": true },
+    "é": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ê": { "accentChar": "^", "keyChar": "~", "needsShift": true },
+    "í": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ó": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ô": { "accentChar": "^", "keyChar": "~", "needsShift": true },
+    "õ": { "accentChar": "~", "keyChar": "~", "needsShift": false },
+    "ú": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ü": { "accentChar": "¨", "keyChar": "6", "needsShift": true }
   }
 }

--- a/assets/layouts/azerty.json
+++ b/assets/layouts/azerty.json
@@ -41,9 +41,18 @@
   "practiceKeys": {
     "homeRow": ["q", "s", "d", "f", "g", "h", "j", "k", "l", "m"],
     "alphabet": [
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
       "é", "è", "ê", "à", "â", "ç", "ù", "û", "ü", "î", "ï", "ô"
     ]
+  },
+  "accentMap": {
+    "â": { "accentChar": "^", "keyChar": "^", "needsShift": false },
+    "ê": { "accentChar": "^", "keyChar": "^", "needsShift": false },
+    "î": { "accentChar": "^", "keyChar": "^", "needsShift": false },
+    "ô": { "accentChar": "^", "keyChar": "^", "needsShift": false },
+    "û": { "accentChar": "^", "keyChar": "^", "needsShift": false },
+    "ï": { "accentChar": "¨", "keyChar": "^", "needsShift": true },
+    "ü": { "accentChar": "¨", "keyChar": "^", "needsShift": true }
   }
 }

--- a/assets/layouts/jis.json
+++ b/assets/layouts/jis.json
@@ -41,8 +41,9 @@
   "practiceKeys": {
     "homeRow": ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", ":"],
     "alphabet": [
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
     ]
-  }
+  },
+  "accentMap": {}
 }

--- a/assets/layouts/qwerty.json
+++ b/assets/layouts/qwerty.json
@@ -39,8 +39,9 @@
   "practiceKeys": {
     "homeRow": ["a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'"],
     "alphabet": [
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
     ]
-  }
+  },
+  "accentMap": {}
 }

--- a/assets/layouts/qwerty_es.json
+++ b/assets/layouts/qwerty_es.json
@@ -40,9 +40,17 @@
   "practiceKeys": {
     "homeRow": ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ"],
     "alphabet": [
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
       "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
       "ñ", "á", "é", "í", "ó", "ú", "ü"
     ]
+  },
+  "accentMap": {
+    "á": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "é": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "í": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ó": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ú": { "accentChar": "´", "keyChar": "´", "needsShift": false },
+    "ü": { "accentChar": "¨", "keyChar": "´", "needsShift": true }
   }
 }


### PR DESCRIPTION
## Summary
- include `accentMap` data in keyboard layouts
- use layout accent map when resolving accent keys
- highlight accent key only when a dead-key sequence is required

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68992e8b492883238f5ff83b74efa290