### PR TITLE
Hide weak key stats after game

### DIFF
--- a/result.html
+++ b/result.html
@@ -36,7 +36,7 @@
                     <canvas id="score-chart"></canvas>
                 </div>
             </div>
-            <div>
+            <div id="weak-key-section">
                 <h2 data-translate-key="keyStatsTitle">苦手キー分析 (ミスタッチ数)</h2>
                 <div id="key-stats-grid" class="key-stats-grid"></div>
             </div>

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -10,6 +10,7 @@ const clearHistoryButton = document.getElementById('clear-history-button');
 const stageSelect = document.getElementById('stage-select');
 const keyStatsGrid = document.getElementById('key-stats-grid');
 const chartCanvas = document.getElementById('score-chart');
+const weakKeySection = document.getElementById('weak-key-section');
 
 let lastResult = null;
 let statsData = null;
@@ -145,6 +146,7 @@ async function initialize() {
         scoreEl.textContent = lastResult.score.toLocaleString();
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
+        weakKeySection.style.display = 'none';
     } else {
         resultSummaryEl.style.display = 'none';
         retryButton.style.display = 'none';


### PR DESCRIPTION
## Summary
- Add `weak-key-section` id to weak key stats block
- Toggle weak key section off after game results load

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a1cfea8fec832389c8dcbc5eac4e6a