### PR TITLE
Reset last result when viewing stats

### DIFF
--- a/main.js
+++ b/main.js
@@ -235,7 +235,10 @@ ipcMain.handle('get-translation', (event, lang) => {
         return {};
     }
 });
-ipcMain.on('navigate-to-stats', () => { mainWindow.loadFile('result.html'); });
+ipcMain.on('navigate-to-stats', () => {
+    lastGameResult = null;
+    mainWindow.loadFile('result.html');
+});
 ipcMain.handle('get-layout', (event, layoutName) => {
     try {
         const filePath = getAssetPath('layouts', `${layoutName}.json`);


### PR DESCRIPTION
## Summary
- Clear stored game result before navigating to statistics

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1cfebbdc08323bef0431a3c2d1d11