### PR TITLE
Refine result message handling

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -289,7 +289,7 @@ function singleChar_clearHighlight() {
     singleChar_highlightedKeyElements = [];
 }
 
-async function saveResultAndExit(message) {
+async function saveResultAndExit(endMessage) {
     const timeBonus = timeLeft > 0 ? timeLeft * 100 : 0;
     const totalScore = score + timeBonus;
 
@@ -299,7 +299,7 @@ async function saveResultAndExit(message) {
         timeBonus: timeBonus,
         totalScore: totalScore,
         mistakes: keyMistakeStats,
-        endMessage: message
+        endMessage
     };
 
     await window.electronAPI.saveGameResult(resultData);
@@ -858,8 +858,8 @@ async function stopGame(message) {
 }
 
 function gameClear(customMessage) {
-    const message = customMessage || currentTranslation.alertClearTitle;
-    saveResultAndExit(message);
+    const endMessage = customMessage || currentTranslation.alertClearTitle;
+    saveResultAndExit(endMessage);
 }
 
 function gameOver(customMessage) { // customMessageを受け取れるように変更
@@ -878,8 +878,8 @@ function gameOver(customMessage) { // customMessageを受け取れるように�
         judgeRaceResult();
         return;
     }
-    const message = customMessage || currentTranslation.alertTimeUp;
-    saveResultAndExit(message);
+    const endMessage = customMessage || currentTranslation.alertTimeUp;
+    saveResultAndExit(endMessage);
 
 }
 

--- a/result.html
+++ b/result.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <div class="container">
-        <h1 id="end-message" data-translate-key="alertClearTitle">クリア！</h1>
+        <h1 id="end-message"></h1>
 
         <div id="result-summary" class="result-summary">
             <table>

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -141,7 +141,11 @@ async function initialize() {
     ]);
 
     if (lastResult) {
-        endMessageEl.textContent = lastResult.endMessage;
+        if (lastResult.endMessage) {
+            endMessageEl.textContent = lastResult.endMessage;
+        } else {
+            endMessageEl.style.display = 'none';
+        }
         scoreEl.textContent = lastResult.score.toLocaleString();
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();


### PR DESCRIPTION
## Summary
- Remove placeholder text and translation key from result header
- Only show end message when a game result exists
- Pass localized end messages from game logic to result screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1cfed146083239075887f01b84270