### PR TITLE
feat: add manual viewer to menu

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -96,6 +96,8 @@
     "attemptLabel": "Attempt {n}",
     "scoreLabel": "Score",
 
+    "manualTitle": "Manual",
+    "menuManual": "Manual",
     "aboutTitle": "About this App",
     "menuAbout": "About this App",
     "aboutAppNameLabel": "App Name",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -104,5 +104,7 @@
   "stageOptionPrefix": "Nivel ",
   "mistakeUnit": " veces",
   "attemptLabel": "Intento {n}",
-  "scoreLabel": "Puntuación"
+  "scoreLabel": "Puntuación",
+  "manualTitle": "Manual",
+  "menuManual": "Manual"
 }

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -104,6 +104,8 @@
     "stageOptionPrefix": "Niveau ",
     "mistakeUnit": " fois",
     "attemptLabel": "Tentative {n}",
-    "scoreLabel": "Score"
+    "scoreLabel": "Score",
+    "manualTitle": "Manuel",
+    "menuManual": "Manuel"
   }
   

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -97,6 +97,8 @@
     "attemptLabel": "{n}回目",
     "scoreLabel": "スコア",
 
+    "manualTitle": "マニュアル",
+    "menuManual": "マニュアル",
     "aboutTitle": "このアプリについて",
     "menuAbout": "アプリについて",
     "aboutCreditsTitle": "アセット（素材）について",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -104,5 +104,7 @@
   "stageOptionPrefix": "Fase ",
   "mistakeUnit": " vezes",
   "attemptLabel": "Tentativa {n}",
-  "scoreLabel": "Pontuação"
+  "scoreLabel": "Pontuação",
+  "manualTitle": "Manual",
+  "menuManual": "Manual"
 }

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -104,5 +104,7 @@
   "stageOptionPrefix": "Urwego ",
   "mistakeUnit": " inshuro",
   "attemptLabel": "Igerageza {n}",
-  "scoreLabel": "Amanota"
+  "scoreLabel": "Amanota",
+  "manualTitle": "Imfashanyigisho",
+  "menuManual": "Imfashanyigisho"
 }

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -104,5 +104,7 @@
   "stageOptionPrefix": "Hatua ",
   "mistakeUnit": " mara",
   "attemptLabel": "Jaribio {n}",
-  "scoreLabel": "Alama"
+  "scoreLabel": "Alama",
+  "manualTitle": "Mwongozo",
+  "menuManual": "Mwongozo"
 }

--- a/main.js
+++ b/main.js
@@ -267,6 +267,25 @@ ipcMain.handle('get-word-list', (event, lang) => {
     }
 });
 
+ipcMain.handle('get-manual-content', (event, lang) => {
+    try {
+        const baseDir = app.isPackaged
+            ? path.join(process.resourcesPath, 'manual')
+            : path.join(__dirname, 'manual');
+        const filePath = path.join(baseDir, `${lang}.txt`);
+        const fallbackPath = path.join(baseDir, 'en.txt');
+        if (fs.existsSync(filePath)) {
+            return fs.readFileSync(filePath, 'utf-8');
+        } else if (fs.existsSync(fallbackPath)) {
+            return fs.readFileSync(fallbackPath, 'utf-8');
+        }
+        return '';
+    } catch (error) {
+        console.error('マニュアルの読み込みに失敗しました:', error);
+        return '';
+    }
+});
+
 // (追加) レース用の単語リストを取得するAPI
 ipcMain.handle('get-race-word-list', () => {
     return currentRaceWordList;
@@ -344,6 +363,10 @@ ipcMain.handle('get-last-game-result', () => {
 
 ipcMain.on('navigate-to-about', () => {
     mainWindow.loadFile('about.html');
+});
+
+ipcMain.on('navigate-to-manual', () => {
+    mainWindow.loadFile('manual.html');
 });
 
 // --- ネットワークAPI ---

--- a/mainMenu.html
+++ b/mainMenu.html
@@ -15,8 +15,9 @@
             <button class="menu-button" id="start-button" data-translate-key="menuStart">ゲームスタート</button>
             <button class="menu-button" id="stats-button" data-translate-key="menuStats">統計データ</button>
             <button class="menu-button" id="settings-button" data-translate-key="menuSettings">設 定</button>
+            <button class="menu-button" id="manual-button" data-translate-key="menuManual">マニュアル</button>
             <button class="menu-button" id="about-button" data-translate-key="menuAbout">このアプリについて</button>
-            
+
         </div>
     </div>
 

--- a/mainMenu.renderer.js
+++ b/mainMenu.renderer.js
@@ -40,6 +40,10 @@ document.getElementById('settings-button').addEventListener('click', () => {
     window.electronAPI.navigateToSettings();
 });
 
+document.getElementById('manual-button').addEventListener('click', () => {
+    window.electronAPI.navigateToManual();
+});
+
 document.getElementById('about-button').addEventListener('click', () => {
     window.electronAPI.navigateToAbout();
 });

--- a/manual.html
+++ b/manual.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title data-translate-key="manualTitle">マニュアル</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        #manual-content {
+            width: 95%;
+            height: 70vh;
+            font-size: 1em;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1 data-translate-key="manualTitle">マニュアル</h1>
+        <textarea id="manual-content" readonly></textarea>
+        <button class="menu-button" id="back-button" data-translate-key="backButton">もどる</button>
+    </div>
+    <script src="manual.renderer.js"></script>
+</body>
+</html>

--- a/manual.renderer.js
+++ b/manual.renderer.js
@@ -1,0 +1,25 @@
+const manualContentEl = document.getElementById('manual-content');
+const backButton = document.getElementById('back-button');
+
+let currentTranslation = {};
+
+function translateUI() {
+    document.querySelectorAll('[data-translate-key]').forEach(el => {
+        const key = el.getAttribute('data-translate-key');
+        if (currentTranslation[key]) el.textContent = currentTranslation[key];
+    });
+}
+
+async function initialize() {
+    const settings = await window.electronAPI.getSettings();
+    currentTranslation = await window.electronAPI.getTranslation(settings.language);
+    translateUI();
+    const content = await window.electronAPI.getManualContent(settings.language);
+    manualContentEl.value = content;
+}
+
+backButton.addEventListener('click', () => {
+    window.electronAPI.navigateToMainMenu();
+});
+
+initialize();

--- a/preload.js
+++ b/preload.js
@@ -5,9 +5,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 設定API
     getSettings: () => ipcRenderer.invoke('get-settings'),
     saveSettings: (settings) => ipcRenderer.invoke('save-settings', settings), 
-    getTranslation: (lang) => ipcRenderer.invoke('get-translation', lang), 
-    getLayout: (layoutName) => ipcRenderer.invoke('get-layout', layoutName), 
-    getWordList: (lang) => ipcRenderer.invoke('get-word-list', lang), 
+    getTranslation: (lang) => ipcRenderer.invoke('get-translation', lang),
+    getLayout: (layoutName) => ipcRenderer.invoke('get-layout', layoutName),
+    getWordList: (lang) => ipcRenderer.invoke('get-word-list', lang),
+    getManualContent: (lang) => ipcRenderer.invoke('get-manual-content', lang),
     getAppInfo: () => ipcRenderer.invoke('get-app-info'),
     openExternalLink: (url) => ipcRenderer.send('open-external-link', url),
     getCreditsData: () => ipcRenderer.invoke('get-credits-data'),
@@ -28,6 +29,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     navigateToResult: (result) => ipcRenderer.send('navigate-to-result', result),
     getLastGameResult: () => ipcRenderer.invoke('get-last-game-result'),
     navigateToAbout: () => ipcRenderer.send('navigate-to-about'),
+    navigateToManual: () => ipcRenderer.send('navigate-to-manual'),
 
     // ゲーム画面で使うAPI (New!)
     getCurrentStageId: () => ipcRenderer.invoke('get-current-stage-id'),


### PR DESCRIPTION
## Summary
- add Manual button to main menu
- load language-specific manual text files in new manual page
- expose manual navigation and content APIs

## Testing
- `npm test`
- `node -e "const fs=require('fs');fs.readdirSync('assets/lang').forEach(f=>{JSON.parse(fs.readFileSync('assets/lang/'+f))});console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68a1e5f49fd88323b4d215a20e9fffab