### PR TITLE
Ensure keyboard layout shows left-to-right in RTL languages

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,7 +80,7 @@ h2 { color: #8d6e63; border-bottom: 2px dashed #ffccbc; padding-bottom: 5px; }
 .info-value { display: block; font-size: 2.5em; color: #ff8a65; font-weight: bold; transition: color 0.5s ease; }
 #countdown-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0, 0, 0, 0.7); display: flex; justify-content: center; align-items: center; z-index: 1000; }
 #countdown-text { font-size: 15em; color: white; font-weight: bold; }
-#keyboard-layout { display: flex; flex-direction: column; gap: 8px; padding: 10px; background-color: #e0e0e0; border-radius: 10px; margin-bottom: 20px; }
+#keyboard-layout { display: flex; flex-direction: column; gap: 8px; padding: 10px; background-color: #e0e0e0; border-radius: 10px; margin-bottom: 20px; direction: ltr; }
 .key-row { display: flex; justify-content: center; gap: 8px; }
 .key { width: 60px; height: 60px; background-color: #fafafa; border-radius: 8px; display: flex; justify-content: center; align-items: center; font-size: 1.5em; font-weight: bold; color: #5d4037; border-bottom: 4px solid #bdbdbd; transition: all 0.05s; }
 .key.pressed { transform: translateY(2px); border-bottom-width: 2px; background-color: #ff8a65; }


### PR DESCRIPTION
## Summary
- Prevent keyboard layout from mirroring when the app is in an RTL language

## Testing
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3220004ec8323aa65a724c46bda87