### PR TITLE
Add score table fallback for Windows 7

### DIFF
--- a/result.html
+++ b/result.html
@@ -32,8 +32,14 @@
             <div>
                 <h2 data-translate-key="scoreTransition">スコア推移</h2>
                 <select id="stage-select" class="custom-select"></select>
-                <div class="chart-container" style="width: 100%; height: 300px; margin-top: 20px;">
+                <div class="chart-container" id="chart-container" style="width: 100%; height: 300px; margin-top: 20px;">
                     <canvas id="score-chart"></canvas>
+                </div>
+                <div id="score-table-container" class="score-table-container" style="display: none;">
+                    <table id="score-table">
+                        <thead></thead>
+                        <tbody></tbody>
+                    </table>
                 </div>
             </div>
             <div id="weak-key-section">

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -9,8 +9,14 @@ const backButton = document.getElementById('back-button');
 const clearHistoryButton = document.getElementById('clear-history-button');
 const stageSelect = document.getElementById('stage-select');
 const keyStatsGrid = document.getElementById('key-stats-grid');
+const chartContainer = document.getElementById('chart-container');
 const chartCanvas = document.getElementById('score-chart');
+const scoreTableContainer = document.getElementById('score-table-container');
+const scoreTable = document.getElementById('score-table');
 const weakKeySection = document.getElementById('weak-key-section');
+
+const isWindows7 = navigator.userAgent.includes('Windows NT 6.1');
+const useChart = !isWindows7 && typeof Chart !== 'undefined';
 
 let lastResult = null;
 let statsData = null;
@@ -60,7 +66,38 @@ function renderKeyStats() {
     });
 }
 
+function renderScoreTable(stageKey) {
+    chartContainer.style.display = 'none';
+    scoreTableContainer.style.display = 'block';
+    const thead = scoreTable.querySelector('thead');
+    const tbody = scoreTable.querySelector('tbody');
+    thead.innerHTML = '';
+    tbody.innerHTML = '';
+    if (!statsData || !statsData.scoreHistory || !statsData.scoreHistory[stageKey]) {
+        return;
+    }
+    const attemptHeader = currentTranslation.attemptHeader || '#';
+    const scoreHeader = currentTranslation.scoreLabel || 'Score';
+    const headerRow = document.createElement('tr');
+    headerRow.innerHTML = `<th>${attemptHeader}</th><th>${scoreHeader}</th>`;
+    thead.appendChild(headerRow);
+    const history = statsData.scoreHistory[stageKey];
+    const maxScore = Math.max(...history.map(h => h.score));
+    history.forEach((h, i) => {
+        const row = document.createElement('tr');
+        if (h.score === maxScore) row.classList.add('highlight');
+        row.innerHTML = `<td>${i + 1}</td><td>${h.score.toLocaleString()}</td>`;
+        tbody.appendChild(row);
+    });
+}
+
 function renderChart(stageKey) {
+    if (!useChart) {
+        renderScoreTable(stageKey);
+        return;
+    }
+    chartContainer.style.display = 'block';
+    scoreTableContainer.style.display = 'none';
     if (scoreChart) {
         scoreChart.destroy();
     }

--- a/style.css
+++ b/style.css
@@ -384,3 +384,25 @@ dialog.modal-dialog::backdrop {
     padding: 8px 12px;
     border-bottom: 1px solid #eee;
 }
+
+/* --- 統計画面 スコアテーブル --- */
+.score-table-container {
+    max-height: 300px;
+    overflow-y: auto;
+    margin-top: 20px;
+}
+
+#score-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+#score-table th,
+#score-table td {
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+}
+
+#score-table tr.highlight {
+    background-color: #fff9c4;
+}


### PR DESCRIPTION
## Summary
- Show score history in a scrollable table when Chart.js isn't supported (Windows 7)
- Highlight the highest score in the history table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3261c07f08323875489725b18c8c4