### PR TITLE
Use table stats on Windows 7

### DIFF
--- a/result.html
+++ b/result.html
@@ -55,7 +55,11 @@
         </div>
     </div>
 
-    <script src="./node_modules/chart.js/dist/chart.umd.js"></script>
+    <script>
+        if (!navigator.userAgent.includes('Windows NT 6.1')) {
+            document.write('<script src="./node_modules/chart.js/dist/chart.umd.js"><\/script>');
+        }
+    </script>
     <script src="modal.js"></script>
     <script src="result.renderer.js"></script>
 </body>

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -18,6 +18,11 @@ const weakKeySection = document.getElementById('weak-key-section');
 const isWindows7 = navigator.userAgent.includes('Windows NT 6.1');
 const useChart = !isWindows7 && typeof Chart !== 'undefined';
 
+if (!useChart) {
+    chartContainer.style.display = 'none';
+    scoreTableContainer.style.display = 'block';
+}
+
 let lastResult = null;
 let statsData = null;
 let scoreChart = null;


### PR DESCRIPTION
## Summary
- Avoid loading Chart.js on Windows 7 and switch stats to table view
- Hide chart container early when charts are disabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a32b4b2180832398254c4bd20aa6f4