### PR TITLE
Limit weak-key practice to current layout

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -1113,7 +1113,9 @@ async function initialize() {
     if (stageId === 9) {
         const statsData = await window.electronAPI.getStatsData();
         if (statsData && statsData.keyStats) {
+            const availableKeys = new Set(STAGE_CONFIG[2].questionKeys);
             const topKeys = Object.entries(statsData.keyStats)
+                .filter(([key]) => availableKeys.has(key))
                 .sort((a, b) => b[1].mistakes - a[1].mistakes)
                 .slice(0, 10)
                 .map(([key]) => key);


### PR DESCRIPTION
## Summary
- Restrict Stage 9 weak-key practice to keys in the active layout

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6904379d88323be79757a60fdb450