### PR TITLE
Add accuracy metrics to statistics page

### DIFF
--- a/assets/lang/ar.json
+++ b/assets/lang/ar.json
@@ -115,6 +115,7 @@
     "mistakeUnit": " مرة",
     "attemptLabel": "المحاولة {n}",
     "scoreLabel": "النتيجة",
+    "accuracyLabel": "الدقة",
     "manualTitle": "دليل",
     "menuManual": "دليل",
     "aboutTitle": "حول هذا التطبيق",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -95,6 +95,7 @@
     "mistakeUnit": " times",
     "attemptLabel": "Attempt {n}",
     "scoreLabel": "Score",
+    "accuracyLabel": "Accuracy",
 
     "manualTitle": "Manual",
     "menuManual": "Manual",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -102,9 +102,10 @@
   "clearHistoryButton": "Borrar historial",
   "confirmClearHistory": "¿Seguro que quieres borrar tu historial?",
   "stageOptionPrefix": "Nivel ",
-  "mistakeUnit": " veces",
-  "attemptLabel": "Intento {n}",
-  "scoreLabel": "Puntuación",
-  "manualTitle": "Manual",
+    "mistakeUnit": " veces",
+    "attemptLabel": "Intento {n}",
+    "scoreLabel": "Puntuación",
+    "accuracyLabel": "Precisión",
+    "manualTitle": "Manual",
   "menuManual": "Manual"
 }

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -105,6 +105,7 @@
     "mistakeUnit": " fois",
     "attemptLabel": "Tentative {n}",
     "scoreLabel": "Score",
+    "accuracyLabel": "Précision",
     "manualTitle": "Manuel",
     "menuManual": "Manuel"
   }

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -96,6 +96,7 @@
     "mistakeUnit": "回",
     "attemptLabel": "{n}回目",
     "scoreLabel": "スコア",
+    "accuracyLabel": "正確率",
 
     "manualTitle": "マニュアル",
     "menuManual": "マニュアル",

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -102,9 +102,10 @@
   "clearHistoryButton": "Limpar histórico",
   "confirmClearHistory": "Tem certeza de que deseja limpar seu histórico?",
   "stageOptionPrefix": "Fase ",
-  "mistakeUnit": " vezes",
-  "attemptLabel": "Tentativa {n}",
-  "scoreLabel": "Pontuação",
-  "manualTitle": "Manual",
+    "mistakeUnit": " vezes",
+    "attemptLabel": "Tentativa {n}",
+    "scoreLabel": "Pontuação",
+    "accuracyLabel": "Precisão",
+    "manualTitle": "Manual",
   "menuManual": "Manual"
 }

--- a/assets/lang/rw.json
+++ b/assets/lang/rw.json
@@ -105,6 +105,7 @@
   "mistakeUnit": " inshuro",
   "attemptLabel": "Igerageza {n}",
   "scoreLabel": "Amanota",
+  "accuracyLabel": "Ukuri",
   "manualTitle": "Imfashanyigisho",
   "menuManual": "Imfashanyigisho"
 }

--- a/assets/lang/sw.json
+++ b/assets/lang/sw.json
@@ -105,6 +105,7 @@
   "mistakeUnit": " mara",
   "attemptLabel": "Jaribio {n}",
   "scoreLabel": "Alama",
+  "accuracyLabel": "Usahihi",
   "manualTitle": "Mwongozo",
   "menuManual": "Mwongozo"
 }

--- a/game.renderer.js
+++ b/game.renderer.js
@@ -159,6 +159,7 @@ let currentConfig = {};
 let gameLoopId = null;
 
 let keyMistakeStats = {}; // (追加) このゲーム中のキーごとのミスを記録するオブジェクト
+let correctKeyPresses = 0; // 正しく押されたキーの数
 
 // --- wordAsteroidモード用の変数 ---
 let word_currentWord = '';
@@ -294,11 +295,16 @@ async function saveResultAndExit(endMessage) {
     const timeBonus = timeLeft > 0 ? timeLeft * 100 : 0;
     const totalScore = score + timeBonus;
 
+    const totalMistakes = Object.values(keyMistakeStats).reduce((sum, count) => sum + count, 0);
+    const totalInputs = correctKeyPresses + totalMistakes;
+    const accuracy = totalInputs > 0 ? Math.round((correctKeyPresses / totalInputs) * 1000) / 10 : 0;
+
     const resultData = {
         stageId: currentConfig.id,
         score: score,
         timeBonus: timeBonus,
         totalScore: totalScore,
+        accuracy: accuracy,
         mistakes: keyMistakeStats,
         endMessage
     };
@@ -587,6 +593,7 @@ function handleKeyPress(event) {
 
         const ok = processWordInput(key);
         if (ok) {
+            correctKeyPresses++;
             if (settings.sfx) { typeAudio.currentTime = 0; typeAudio.play(); }
             setAnimalState(myProgressAnimal, MY_ANIMAL_IMAGES, 'normal');
             updateWordAsteroidDisplay();
@@ -637,6 +644,7 @@ function handleKeyPress(event) {
 
         const ok = processWordInput(key);
         if (ok) {
+            correctKeyPresses++;
             if (settings.sfx) { typeAudio.currentTime = 0; typeAudio.play(); }
 
             if (word_typedWord === word_currentWord) {
@@ -674,6 +682,7 @@ function handleKeyPress(event) {
 
         const ok = processWordInput(key);
         if (ok) {
+            correctKeyPresses++;
             if (settings.sfx) { typeAudio.currentTime = 0; typeAudio.play(); }
 
             if (word_typedWord === word_currentWord) {
@@ -716,6 +725,7 @@ function handleKeyPress(event) {
     } else if (currentConfig.gameMode === 'fallingStars') {
         const targetStarIndex = activeStars.findIndex(s => s.char === key);
         if (targetStarIndex !== -1) {
+            correctKeyPresses++;
             const targetStar = activeStars[targetStarIndex];
             if (targetStar.isBouncing) return;
 
@@ -813,6 +823,7 @@ function handleKeyPress(event) {
         }
         const expectedChar = singleChar_inputSequence[singleChar_sequenceIndex] || singleChar_currentQuestion;
         if (key === expectedChar) {
+            correctKeyPresses++;
             if (singleChar_accentInfo && singleChar_sequenceIndex === 0 && singleChar_inputSequence.length > 1) {
                 singleChar_sequenceIndex++;
                 singleChar_clearHighlight();
@@ -922,6 +933,7 @@ function startGame() {
     isPlaying = true;
     score = 0;
     totalCorrectTyped = 0;
+    correctKeyPresses = 0;
     timeLeft = currentConfig.timeLimit;
     scoreDisplay.textContent = score;
     timerDisplay.textContent = timeLeft;

--- a/main.js
+++ b/main.js
@@ -142,6 +142,7 @@ ipcMain.handle('save-game-result', async (event, result) => {
     // 新しいスコアを追加（トータルスコアを保存）
     userData.scoreHistory[stageKey].push({
         score: result.totalScore || result.score,
+        accuracy: result.accuracy,
         date: new Date().toISOString()
     });
 

--- a/result.html
+++ b/result.html
@@ -24,6 +24,10 @@
                         <th data-translate-key="alertTotalScore">合計スコア</th>
                         <td id="total-score">0</td>
                     </tr>
+                    <tr>
+                        <th data-translate-key="accuracyLabel">正確率</th>
+                        <td id="accuracy">0%</td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -3,6 +3,7 @@ const resultSummaryEl = document.getElementById('result-summary');
 const scoreEl = document.getElementById('score');
 const timeBonusEl = document.getElementById('time-bonus');
 const totalScoreEl = document.getElementById('total-score');
+const accuracyEl = document.getElementById('accuracy');
 
 const retryButton = document.getElementById('retry-button');
 const backButton = document.getElementById('back-button');
@@ -83,15 +84,17 @@ function renderScoreTable(stageKey) {
     }
     const attemptHeader = currentTranslation.attemptHeader || '#';
     const scoreHeader = currentTranslation.scoreLabel || 'Score';
+    const accuracyHeader = currentTranslation.accuracyLabel || 'Accuracy';
     const headerRow = document.createElement('tr');
-    headerRow.innerHTML = `<th>${attemptHeader}</th><th>${scoreHeader}</th>`;
+    headerRow.innerHTML = `<th>${attemptHeader}</th><th>${scoreHeader}</th><th>${accuracyHeader}</th>`;
     thead.appendChild(headerRow);
     const history = statsData.scoreHistory[stageKey];
     const maxScore = Math.max(...history.map(h => h.score));
     history.forEach((h, i) => {
         const row = document.createElement('tr');
         if (h.score === maxScore) row.classList.add('highlight');
-        row.innerHTML = `<td>${i + 1}</td><td>${h.score.toLocaleString()}</td>`;
+        const accuracyText = h.accuracy != null ? `${h.accuracy.toFixed(1)}%` : '-';
+        row.innerHTML = `<td>${i + 1}</td><td>${h.score.toLocaleString()}</td><td>${accuracyText}</td>`;
         tbody.appendChild(row);
     });
 }
@@ -193,6 +196,7 @@ async function initialize() {
         scoreEl.textContent = lastResult.score.toLocaleString();
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
+        accuracyEl.textContent = lastResult.accuracy != null ? `${lastResult.accuracy.toFixed(1)}%` : '-';
         weakKeySection.style.display = 'none';
     } else {
         resultSummaryEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- Track correct key presses and compute accuracy for each game
- Save accuracy in user stats and show it on the results page and history table
- Add translations for the new accuracy label

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aac5f1a7e88323a4ebd8529855264a