### PR TITLE
Track overall typing accuracy across sessions

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -306,6 +306,8 @@ async function saveResultAndExit(endMessage) {
         totalScore: totalScore,
         accuracy: accuracy,
         mistakes: keyMistakeStats,
+        correctKeyPresses: correctKeyPresses,
+        totalMistakes: totalMistakes,
         endMessage
     };
 

--- a/main.js
+++ b/main.js
@@ -146,6 +146,12 @@ ipcMain.handle('save-game-result', async (event, result) => {
         date: new Date().toISOString()
     });
 
+    // (追加) 累計の正解数・ミス数を更新
+    if (!userData.totalCorrect) userData.totalCorrect = 0;
+    if (!userData.totalMistakes) userData.totalMistakes = 0;
+    userData.totalCorrect += result.correctKeyPresses || 0;
+    userData.totalMistakes += result.totalMistakes || 0;
+
     // キーごとのミス統計をマージ
     if (!userData.keyStats) userData.keyStats = {};
     for (const key in result.mistakes) {
@@ -172,6 +178,8 @@ ipcMain.handle('clear-user-history', () => {
         const userData = loadUserData(currentUser) || {};
         userData.scoreHistory = {};
         userData.keyStats = {};
+        userData.totalCorrect = 0;
+        userData.totalMistakes = 0;
         saveUserData(currentUser, userData);
         return { success: true };
     } catch (error) {
@@ -300,7 +308,11 @@ ipcMain.handle('login-or-create-user', async (event, userName) => {
             const newUser = {
                 userName: userName,
                 createdAt: new Date().toISOString(),
-                highScores: {}
+                highScores: {},
+                scoreHistory: {},
+                keyStats: {},
+                totalCorrect: 0,
+                totalMistakes: 0
             };
             fs.writeFileSync(filePath, JSON.stringify(newUser, null, 2));
         }

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -196,7 +196,9 @@ async function initialize() {
         scoreEl.textContent = lastResult.score.toLocaleString();
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
-        accuracyEl.textContent = lastResult.accuracy != null ? `${lastResult.accuracy.toFixed(1)}%` : '-';
+        const totalInputs = (statsData?.totalCorrect || 0) + (statsData?.totalMistakes || 0);
+        const overallAccuracy = totalInputs > 0 ? (statsData.totalCorrect / totalInputs) * 100 : null;
+        accuracyEl.textContent = overallAccuracy != null ? `${overallAccuracy.toFixed(1)}%` : '-';
         weakKeySection.style.display = 'none';
     } else {
         resultSummaryEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- Persist cumulative correct and incorrect key counts for each user.
- Initialize and reset accuracy totals when creating or clearing user data.
- Compute result screen accuracy from accumulated stats instead of single runs.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aaca07172083239882ae1966aebaeb