### PR TITLE
Fix accuracy calculation formula

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -297,7 +297,9 @@ async function saveResultAndExit(endMessage) {
 
     const totalMistakes = Object.values(keyMistakeStats).reduce((sum, count) => sum + count, 0);
     const totalInputs = correctKeyPresses + totalMistakes;
-    const accuracy = totalInputs > 0 ? Math.round((correctKeyPresses / totalInputs) * 1000) / 10 : 0;
+    const accuracy = totalInputs > 0
+        ? Math.round(((totalInputs - totalMistakes) / totalInputs) * 1000) / 10
+        : 0;
 
     const resultData = {
         stageId: currentConfig.id,

--- a/result.renderer.js
+++ b/result.renderer.js
@@ -197,7 +197,9 @@ async function initialize() {
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
         const totalInputs = (statsData?.totalCorrect || 0) + (statsData?.totalMistakes || 0);
-        const overallAccuracy = totalInputs > 0 ? (statsData.totalCorrect / totalInputs) * 100 : null;
+        const overallAccuracy = totalInputs > 0
+            ? ((totalInputs - (statsData?.totalMistakes || 0)) / totalInputs) * 100
+            : null;
         accuracyEl.textContent = overallAccuracy != null ? `${overallAccuracy.toFixed(1)}%` : '-';
         weakKeySection.style.display = 'none';
     } else {


### PR DESCRIPTION
## Summary
- compute accuracy as (input count - mistakes) / input count
- update result screen to apply new accuracy formula

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aacfe500a083239fa61a3c2621bc60