### PR TITLE
Fix accuracy display to reflect current game

### DIFF
--- a/result.renderer.js
+++ b/result.renderer.js
@@ -196,11 +196,10 @@ async function initialize() {
         scoreEl.textContent = lastResult.score.toLocaleString();
         timeBonusEl.textContent = lastResult.timeBonus.toLocaleString();
         totalScoreEl.textContent = lastResult.totalScore.toLocaleString();
-        const totalInputs = (statsData?.totalCorrect || 0) + (statsData?.totalMistakes || 0);
-        const overallAccuracy = totalInputs > 0
-            ? ((totalInputs - (statsData?.totalMistakes || 0)) / totalInputs) * 100
+        const currentAccuracy = lastResult.accuracy != null
+            ? lastResult.accuracy
             : null;
-        accuracyEl.textContent = overallAccuracy != null ? `${overallAccuracy.toFixed(1)}%` : '-';
+        accuracyEl.textContent = currentAccuracy != null ? `${currentAccuracy.toFixed(1)}%` : '-';
         weakKeySection.style.display = 'none';
     } else {
         resultSummaryEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- Show accuracy from the most recent game result instead of cumulative stats

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aafded88108323982d7cad5fc5519f