### PR TITLE
Handle accented characters in falling star and word stages

### DIFF
--- a/game.renderer.js
+++ b/game.renderer.js
@@ -536,7 +536,7 @@ function processWordInput(key) {
         return true; // 正しい入力（未確定含む）
     } else {
         const expected = word_currentWord[word_typedWord.length];
-        if (expected && key === expected.toLowerCase()) {
+        if (expected && removeDiacritics(expected.toLowerCase()) === removeDiacritics(key)) {
             word_typedWord += expected;
             return true;
         }
@@ -727,7 +727,8 @@ function handleKeyPress(event) {
         }
         updateWordAsteroidDisplay();
     } else if (currentConfig.gameMode === 'fallingStars') {
-        const targetStarIndex = activeStars.findIndex(s => s.char === key);
+        if (key.length > 1) return; // 無効なキーを無視
+        const targetStarIndex = activeStars.findIndex(s => removeDiacritics(s.char) === removeDiacritics(key));
         if (targetStarIndex !== -1) {
             correctKeyPresses++;
             const targetStar = activeStars[targetStarIndex];


### PR DESCRIPTION
## Summary
- Accept base characters for accented letters in falling star mode
- Ignore diacritics when matching word inputs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab11af5050832382333fc0c165377b